### PR TITLE
Create expense report builder web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Expenses
+# FSI Expense Report Builder
+
+A lightweight web application for preparing Freight Services expense reports with built-in policy validation.
+
+## Features
+- Persist report header details and expense rows locally.
+- Inline policy reminders for travel, meals, and mileage reimbursements.
+- Automatic reimbursement calculations for capped categories and mileage at the IRS rate.
+- Copy-ready text preview that mirrors the official expense form layout.
+
+## Getting started
+1. Serve the project with any static HTTP server (for example `python -m http.server 8000`).
+2. Open the site in your browser and start adding expenses.
+3. Copy the generated preview text into the company expense template when you are done.
+
+Local storage persistence is optional; if the browser disables access, the app still functions without saving state between sessions.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>FSI Expense Report Builder</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <div class="logo" aria-hidden="true">FSI</div>
+    <div class="header-copy">
+      <h1>Expense Report Builder</h1>
+      <p class="tagline">Collect expenses, validate company policy, and prepare the month-end packet &mdash; even offline.</p>
+    </div>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>Report Header</h2>
+      <div class="grid">
+        <label>Name
+          <input id="field_name" type="text" placeholder="Employee name" autocomplete="name" />
+        </label>
+        <label>Department
+          <input id="field_department" type="text" placeholder="Department or team" />
+        </label>
+        <label>Expense Type / Focus
+          <input id="field_focus" type="text" placeholder="e.g., Mileage &amp; supplies" />
+        </label>
+        <label>Purpose of Trip / Project
+          <input id="field_purpose" type="text" placeholder="Client visit, project, etc." />
+        </label>
+        <label>JE Number
+          <input id="field_je" type="text" placeholder="Optional journal entry #" inputmode="numeric" />
+        </label>
+        <label>Date Range
+          <input id="field_dates" type="text" placeholder="e.g., Dec 4&ndash;7 2023" />
+        </label>
+        <label>Trip Length (days)
+          <input id="field_trip_length" type="number" min="0" step="1" placeholder="0" />
+        </label>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Policy Quick Reference</h2>
+      <details open>
+        <summary>Travel &amp; transportation</summary>
+        <ul>
+          <li>Domestic airfare: book the lowest coach fare available. Upgrades are a personal expense.</li>
+          <li>International airfare: business class only when the published flight time is eight hours or more.</li>
+          <li>Use long-term parking when traveling 36+ hours. Mileage reimbursed at the IRS rate above base commute.</li>
+          <li>Hotel gym fees reimbursable up to $15 per day.</li>
+          <li>Laundry reimbursed only on trips longer than seven full days.</li>
+        </ul>
+      </details>
+      <details>
+        <summary>Meals &amp; entertainment</summary>
+        <ul>
+          <li>Receipts required for every meal. Without one, reimbursement is capped at $10 breakfast, $15 lunch, $25 dinner.</li>
+          <li>Entertainment must be business-related where company business was discussed.</li>
+        </ul>
+      </details>
+      <details>
+        <summary>Non-reimbursable highlights</summary>
+        <ul>
+          <li>First-class airfare, personal entertainment, personal grooming, and traffic fines.</li>
+          <li>Airline club dues, personal sundries, and theft of personal property (unless covered by rental insurance).</li>
+        </ul>
+      </details>
+    </section>
+
+    <section class="card" id="expensesCard">
+      <div class="card-header">
+        <h2>Expenses</h2>
+        <button id="addExpense" type="button">+ Add expense</button>
+      </div>
+      <div class="table-scroll">
+        <table id="expensesTable">
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Type</th>
+              <th scope="col">Account</th>
+              <th scope="col">Description / Details</th>
+              <th scope="col">Payment</th>
+              <th scope="col">Amount</th>
+              <th scope="col">Reimbursable</th>
+              <th scope="col">Policy notes</th>
+              <th scope="col" aria-label="Remove"></th>
+            </tr>
+          </thead>
+          <tbody id="expensesBody"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="card" id="totalsCard">
+      <h2>Totals</h2>
+      <dl class="totals">
+        <div>
+          <dt>Total submitted</dt>
+          <dd id="totalSubmitted">$0.00</dd>
+        </div>
+        <div>
+          <dt>Due to employee</dt>
+          <dd id="totalDueEmployee">$0.00</dd>
+        </div>
+        <div>
+          <dt>Company card</dt>
+          <dd id="totalCompanyCard">$0.00</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="card">
+      <h2>Report Preview</h2>
+      <p class="hint">Snapshot updates automatically. Copy and paste into the official form.</p>
+      <textarea id="reportPreview" readonly rows="12" aria-label="Expense report preview"></textarea>
+      <button id="copyPreview" type="button">Copy summary</button>
+      <p class="copy-feedback" id="copyFeedback" role="status" aria-live="polite"></p>
+    </section>
+  </main>
+
+  <template id="expense-row-template">
+    <tr class="expense-row">
+      <td><input type="date" class="exp-date" /></td>
+      <td>
+        <select class="exp-type"></select>
+        <div class="detail" data-detail="meal">
+          <label>Meal type
+            <select class="exp-meal-type">
+              <option value="breakfast">Breakfast ($10 cap w/out receipt)</option>
+              <option value="lunch">Lunch ($15 cap w/out receipt)</option>
+              <option value="dinner">Dinner ($25 cap w/out receipt)</option>
+            </select>
+          </label>
+          <label class="checkbox"><input type="checkbox" class="exp-receipt" checked /> Receipt provided</label>
+        </div>
+        <div class="detail" data-detail="mileage">
+          <label>Miles driven
+            <input type="number" min="0" step="0.1" class="exp-miles" />
+          </label>
+          <p class="hint">Reimbursed at current IRS rate.</p>
+        </div>
+        <div class="detail" data-detail="travel">
+          <label>Travel category
+            <select class="exp-travel-cat">
+              <option value="air_domestic">Airfare &ndash; Domestic</option>
+              <option value="air_international">Airfare &ndash; International</option>
+              <option value="lodging">Lodging / Hotel</option>
+              <option value="parking">Parking / Tolls</option>
+              <option value="ground">Ground transport (taxi, rideshare, shuttle)</option>
+              <option value="laundry">Laundry / Dry cleaning</option>
+              <option value="gym">Hotel gym</option>
+              <option value="other">Other travel</option>
+            </select>
+          </label>
+          <label data-flight-only>Class of service
+            <select class="exp-travel-class">
+              <option value="coach">Coach</option>
+              <option value="premium">Premium economy</option>
+              <option value="business">Business</option>
+              <option value="first">First</option>
+            </select>
+          </label>
+          <label data-flight-only>Published flight hours
+            <input type="number" min="0" step="0.1" class="exp-flight-hours" placeholder="0" />
+          </label>
+        </div>
+      </td>
+      <td class="expense-account">&mdash;</td>
+      <td>
+        <textarea class="exp-description" rows="2" placeholder="Describe the business purpose"></textarea>
+      </td>
+      <td>
+        <select class="exp-payment">
+          <option value="personal">Personal funds</option>
+          <option value="company">Company card</option>
+        </select>
+      </td>
+      <td>
+        <input type="number" min="0" step="0.01" class="exp-amount" placeholder="0.00" />
+        <div class="detail" data-detail="mileage"><span class="mileage-rate"></span></div>
+      </td>
+      <td class="expense-reimbursable">$0.00</td>
+      <td>
+        <ul class="policy-messages"></ul>
+      </td>
+      <td>
+        <button type="button" class="remove-expense" title="Remove">&times;</button>
+      </td>
+    </tr>
+  </template>
+
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "FSI Expense Report Builder",
+  "short_name": "FSI Expenses",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#0b1120",
+  "theme_color": "#0f172a",
+  "icons": []
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,52 @@
+export const STORAGE_KEY = 'fsi-expense-state-v1';
+export const IRS_RATE = 0.655; // 2023 IRS standard mileage rate per mile.
+
+export const MEAL_LIMITS = Object.freeze({
+  breakfast: 10,
+  lunch: 15,
+  dinner: 25,
+});
+
+export const EXPENSE_TYPES = Object.freeze([
+  { value: 'maintenance_repairs', label: 'Maintenance & Repairs', account: '51020', policy: 'default' },
+  { value: 'parking_storage_cogs', label: 'Parking & Storage - COGS', account: '51070', policy: 'travel', travelDefault: 'parking' },
+  { value: 'vehicle_supplies', label: 'Vehicle Supplies', account: '51090', policy: 'default' },
+  { value: 'state_permits', label: 'State Permits / Fees / Tolls', account: '52030', policy: 'travel', travelDefault: 'other' },
+  { value: 'meals_cogs', label: 'Meals & Entertainment - COGS', account: '52070', policy: 'meal' },
+  { value: 'travel_cogs', label: 'Travel - COGS', account: '52080', policy: 'travel', travelDefault: 'air_domestic' },
+  { value: 'fsi_global_overhead', label: 'FSI Global Overhead', account: '56000', policy: 'default' },
+  { value: 'telephone_ga', label: 'Telephone - GA', account: '62000', policy: 'default' },
+  { value: 'utilities', label: 'Utilities', account: '62070', policy: 'default' },
+  { value: 'it_computer', label: 'IT / Computer', account: '62080', policy: 'default' },
+  { value: 'office_supplies', label: 'Office Supplies', account: '62090', policy: 'default' },
+  { value: 'printing_postage', label: 'Printing & Postage', account: '62100', policy: 'default' },
+  { value: 'meals_ga', label: 'Meals & Entertainment - GA', account: '64180', policy: 'meal' },
+  { value: 'travel_ga', label: 'Travel - GA', account: '64190', policy: 'travel', travelDefault: 'air_domestic' },
+  { value: 'fsi_global_ga', label: 'FSI Global G&A', account: '66500', policy: 'default' },
+  { value: 'mileage', label: 'Mileage reimbursement (IRS rate)', account: '64190', policy: 'mileage' },
+]);
+
+export const DEFAULT_STATE = Object.freeze({
+  header: {
+    name: '',
+    department: '',
+    focus: '',
+    purpose: '',
+    je: '',
+    dates: '',
+    tripLength: '',
+  },
+  expenses: [],
+});
+
+export const headerBindings = Object.freeze({
+  field_name: 'name',
+  field_department: 'department',
+  field_focus: 'focus',
+  field_purpose: 'purpose',
+  field_je: 'je',
+  field_dates: 'dates',
+  field_trip_length: 'tripLength',
+});
+
+export const cloneDefaultState = () => JSON.parse(JSON.stringify(DEFAULT_STATE));

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,517 @@
+import { EXPENSE_TYPES, IRS_RATE, MEAL_LIMITS, headerBindings } from './constants.js';
+import { loadState, saveState } from './storage.js';
+import { fmtCurrency, parseNumber, uuid } from './utils.js';
+
+const state = loadState();
+const expenseRows = new Map();
+
+const elements = {
+  expensesBody: document.querySelector('#expensesBody'),
+  addExpense: document.querySelector('#addExpense'),
+  reportPreview: document.querySelector('#reportPreview'),
+  copyPreview: document.querySelector('#copyPreview'),
+  copyFeedback: document.querySelector('#copyFeedback'),
+  totalSubmitted: document.querySelector('#totalSubmitted'),
+  totalDueEmployee: document.querySelector('#totalDueEmployee'),
+  totalCompanyCard: document.querySelector('#totalCompanyCard'),
+};
+
+const findExpenseType = (value) => EXPENSE_TYPES.find((type) => type.value === value);
+
+const createTypeOptions = (select) => {
+  select.innerHTML = '';
+  EXPENSE_TYPES.forEach((type) => {
+    const option = document.createElement('option');
+    option.value = type.value;
+    option.textContent = `${type.label} (${type.account})`;
+    select.append(option);
+  });
+};
+
+const updateFlightFieldsVisibility = (expense, refs) => {
+  const isAir = expense.travelCategory === 'air_domestic' || expense.travelCategory === 'air_international';
+  refs.flightOnlyBlocks.forEach((block) => {
+    block.style.display = isAir ? '' : 'none';
+  });
+};
+
+const evaluateExpense = (expense) => {
+  const messages = [];
+  let reimbursable = parseNumber(expense.amount);
+
+  if (expense.policy === 'meal') {
+    const mealKey = expense.mealType || 'dinner';
+    const cap = MEAL_LIMITS[mealKey];
+    if (!expense.hasReceipt) {
+      if (reimbursable > cap) {
+        messages.push({ type: 'warning', text: `No receipt: reimbursement capped at ${fmtCurrency(cap)} for ${mealKey}.` });
+      }
+      reimbursable = Math.min(reimbursable, cap);
+    } else if (cap && reimbursable > cap) {
+      messages.push({ type: 'info', text: `Above guideline amount (${fmtCurrency(cap)}). Ensure business justification is noted.` });
+    }
+  }
+
+  if (expense.policy === 'mileage') {
+    reimbursable = parseNumber(expense.miles) * IRS_RATE;
+    expense.amount = reimbursable;
+  }
+
+  if (expense.policy === 'travel') {
+    const category = expense.travelCategory || 'air_domestic';
+    const travelClass = expense.travelClass || 'coach';
+    const hours = parseNumber(expense.flightHours);
+
+    if (category === 'air_domestic') {
+      if (travelClass === 'first') {
+        messages.push({ type: 'warning', text: 'First-class airfare is not reimbursable.' });
+      } else if (travelClass !== 'coach') {
+        messages.push({ type: 'warning', text: 'Domestic airfare should be booked in coach. Upgrades are a personal expense.' });
+      }
+    }
+
+    if (category === 'air_international') {
+      if (travelClass === 'first') {
+        messages.push({ type: 'warning', text: 'First-class airfare is not reimbursable.' });
+      }
+      if (travelClass === 'business' && hours < 8) {
+        messages.push({ type: 'warning', text: 'Business class allowed only when the published flight time is eight hours or longer.' });
+      }
+      if (!['business', 'coach', 'premium'].includes(travelClass)) {
+        messages.push({ type: 'warning', text: 'Select an allowable fare class.' });
+      }
+    }
+
+    if (category === 'gym' && reimbursable > 15) {
+      messages.push({ type: 'warning', text: 'Hotel gym fees should not exceed $15 per day.' });
+    }
+
+    if (category === 'laundry') {
+      const tripLength = parseNumber(state.header.tripLength);
+      if (!tripLength || tripLength < 7) {
+        messages.push({ type: 'warning', text: 'Laundry reimbursed only for trips exceeding seven full days.' });
+      }
+    }
+  }
+
+  expense.reimbursable = reimbursable;
+  expense.messages = messages;
+  return expense;
+};
+
+const updateRowUI = (expense) => {
+  const refs = expenseRows.get(expense.id);
+  if (!refs) return;
+
+  refs.reimbCell.textContent = fmtCurrency(expense.reimbursable || 0);
+  if (expense.policy === 'mileage') {
+    refs.amountInput.value = expense.amount ? expense.amount.toFixed(2) : '';
+  }
+
+  refs.messagesList.innerHTML = '';
+  if (expense.messages?.length) {
+    expense.messages.forEach((message) => {
+      const li = document.createElement('li');
+      li.textContent = message.text;
+      li.className = message.type;
+      refs.messagesList.appendChild(li);
+    });
+  }
+};
+
+const updateTotals = () => {
+  const totals = state.expenses.reduce((acc, expense) => {
+    const amount = parseNumber(expense.amount);
+    const reimb = parseNumber(expense.reimbursable);
+    acc.submitted += amount;
+    if (expense.payment === 'company') {
+      acc.company += reimb;
+    } else {
+      acc.employee += reimb;
+    }
+    return acc;
+  }, { submitted: 0, employee: 0, company: 0 });
+
+  elements.totalSubmitted.textContent = fmtCurrency(totals.submitted);
+  elements.totalDueEmployee.textContent = fmtCurrency(totals.employee);
+  elements.totalCompanyCard.textContent = fmtCurrency(totals.company);
+};
+
+const updatePreview = () => {
+  const lines = [];
+  const header = state.header;
+  lines.push('Expense report');
+  lines.push(`Name: ${header.name || ''}`);
+  lines.push(`Department: ${header.department || ''}`);
+  lines.push(`Expense focus: ${header.focus || ''}`);
+  lines.push(`Purpose: ${header.purpose || ''}`);
+  lines.push(`JE #: ${header.je || ''}`);
+  lines.push(`Dates: ${header.dates || ''}`);
+  if (header.tripLength) {
+    lines.push(`Trip length: ${header.tripLength} day(s)`);
+  }
+  lines.push('');
+  lines.push('Date | Type | Account | Description | Payment | Amount | Reimbursable');
+  lines.push('-----|------|---------|-------------|---------|--------|-------------');
+
+  state.expenses.forEach((expense) => {
+    const meta = findExpenseType(expense.type);
+    const typeLabel = meta ? meta.label : expense.type;
+    const amount = fmtCurrency(parseNumber(expense.amount));
+    const reimb = fmtCurrency(parseNumber(expense.reimbursable));
+
+    lines.push([
+      expense.date || '',
+      typeLabel,
+      expense.account || '',
+      (expense.description || '').replace(/\s+/g, ' ').trim(),
+      expense.payment === 'company' ? 'Company card' : 'Personal',
+      amount,
+      reimb,
+    ].join(' | '));
+
+    if (expense.messages?.length) {
+      expense.messages.forEach((msg) => {
+        lines.push(`  - ${msg.type === 'warning' ? '⚠️' : 'ℹ️'} ${msg.text}`);
+      });
+    }
+  });
+
+  const totalsLine = `Totals -> Submitted: ${elements.totalSubmitted.textContent}, Due to employee: ${elements.totalDueEmployee.textContent}, Company card: ${elements.totalCompanyCard.textContent}`;
+  lines.push('');
+  lines.push(totalsLine);
+
+  elements.reportPreview.value = lines.join('\n');
+};
+
+const persistAndRefresh = (expense, { previewOnly = false } = {}) => {
+  evaluateExpense(expense);
+  const index = state.expenses.findIndex((item) => item.id === expense.id);
+  if (index !== -1) {
+    state.expenses[index] = { ...state.expenses[index], ...expense };
+  }
+  saveState(state);
+  updateRowUI(expense);
+  if (!previewOnly) {
+    updateTotals();
+  }
+  updatePreview();
+};
+
+const applyExpenseType = (expense, refs) => {
+  const meta = findExpenseType(expense.type) || EXPENSE_TYPES[0];
+  expense.policy = meta.policy;
+  expense.account = meta.account;
+  refs.accountCell.textContent = meta.account;
+
+  Object.entries(refs.detailBlocks).forEach(([key, block]) => {
+    if (!block) return;
+    block.hidden = meta.policy !== key;
+  });
+
+  if (meta.policy !== 'mileage') {
+    refs.amountInput.removeAttribute('readonly');
+    refs.amountInput.classList.remove('readonly');
+  }
+
+  if (meta.policy === 'mileage') {
+    refs.amountInput.setAttribute('readonly', 'readonly');
+    refs.amountInput.classList.add('readonly');
+    if (!expense.miles) expense.miles = 0;
+    refs.milesInput.value = expense.miles || '';
+    expense.amount = expense.miles * IRS_RATE;
+    refs.amountInput.value = expense.amount ? expense.amount.toFixed(2) : '';
+  }
+
+  if (meta.policy !== 'meal') {
+    expense.mealType = expense.mealType || 'dinner';
+  }
+
+  if (meta.policy === 'travel') {
+    const defaultCategory = meta.travelDefault || 'air_domestic';
+    expense.travelCategory = expense.travelCategory || defaultCategory;
+    refs.travelCategory.value = expense.travelCategory;
+    updateFlightFieldsVisibility(expense, refs);
+  }
+
+  persistAndRefresh(expense);
+};
+
+const removeExpense = (id) => {
+  const index = state.expenses.findIndex((expense) => expense.id === id);
+  if (index === -1) return;
+
+  state.expenses.splice(index, 1);
+  const refs = expenseRows.get(id);
+  if (refs) {
+    refs.row.remove();
+    expenseRows.delete(id);
+  }
+
+  updateTotals();
+  updatePreview();
+  saveState(state);
+};
+
+const persistAndRefreshHeader = () => {
+  saveState(state);
+  state.expenses.forEach((expense) => {
+    evaluateExpense(expense);
+    updateRowUI(expense);
+  });
+  updateTotals();
+  updatePreview();
+};
+
+const bindHeaderFields = () => {
+  Object.entries(headerBindings).forEach(([id, key]) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const value = state.header[key];
+    if (value !== undefined) el.value = value;
+    el.addEventListener('input', () => {
+      let nextValue = el.value;
+      if (el.type === 'number') {
+        nextValue = nextValue === '' ? '' : Number(nextValue);
+      }
+      state.header[key] = nextValue;
+      persistAndRefreshHeader();
+    });
+  });
+};
+
+const buildRow = (expense) => {
+  const template = document.getElementById('expense-row-template');
+  const fragment = template.content.cloneNode(true);
+  const row = fragment.querySelector('tr');
+  row.dataset.id = expense.id;
+
+  const dateInput = row.querySelector('.exp-date');
+  const typeSelect = row.querySelector('.exp-type');
+  const accountCell = row.querySelector('.expense-account');
+  const description = row.querySelector('.exp-description');
+  const paymentSelect = row.querySelector('.exp-payment');
+  const amountInput = row.querySelector('.exp-amount');
+  const reimbCell = row.querySelector('.expense-reimbursable');
+  const messagesList = row.querySelector('.policy-messages');
+  const removeBtn = row.querySelector('.remove-expense');
+  const mealType = row.querySelector('.exp-meal-type');
+  const receipt = row.querySelector('.exp-receipt');
+  const milesInput = row.querySelector('.exp-miles');
+  const mileageRate = row.querySelector('.mileage-rate');
+  const travelCategory = row.querySelector('.exp-travel-cat');
+  const travelClass = row.querySelector('.exp-travel-class');
+  const flightHours = row.querySelector('.exp-flight-hours');
+  const detailBlocks = {
+    meal: row.querySelector('[data-detail="meal"]'),
+    mileage: row.querySelector('[data-detail="mileage"]'),
+    travel: row.querySelector('[data-detail="travel"]'),
+  };
+  const flightOnlyBlocks = row.querySelectorAll('[data-flight-only]');
+
+  createTypeOptions(typeSelect);
+
+  dateInput.value = expense.date || '';
+  typeSelect.value = expense.type || EXPENSE_TYPES[0].value;
+  description.value = expense.description || '';
+  paymentSelect.value = expense.payment || 'personal';
+  amountInput.value = expense.amount ?? '';
+  reimbCell.textContent = fmtCurrency(expense.reimbursable || 0);
+  mealType.value = expense.mealType || 'dinner';
+  receipt.checked = expense.hasReceipt !== false;
+  milesInput.value = expense.miles || '';
+  travelCategory.value = expense.travelCategory || 'air_domestic';
+  travelClass.value = expense.travelClass || 'coach';
+  flightHours.value = expense.flightHours || '';
+  mileageRate.textContent = `IRS rate $${IRS_RATE.toFixed(3)} per mile`;
+
+  const refs = {
+    row,
+    dateInput,
+    typeSelect,
+    accountCell,
+    description,
+    paymentSelect,
+    amountInput,
+    reimbCell,
+    messagesList,
+    removeBtn,
+    mealType,
+    receipt,
+    milesInput,
+    mileageRate,
+    travelCategory,
+    travelClass,
+    flightHours,
+    detailBlocks,
+    flightOnlyBlocks,
+  };
+
+  expenseRows.set(expense.id, refs);
+
+  typeSelect.addEventListener('change', () => {
+    expense.type = typeSelect.value;
+    applyExpenseType(expense, refs);
+  });
+
+  dateInput.addEventListener('change', () => {
+    expense.date = dateInput.value;
+    persistAndRefresh(expense);
+  });
+
+  description.addEventListener('input', () => {
+    expense.description = description.value;
+    persistAndRefresh(expense, { previewOnly: true });
+  });
+
+  paymentSelect.addEventListener('change', () => {
+    expense.payment = paymentSelect.value;
+    persistAndRefresh(expense);
+  });
+
+  amountInput.addEventListener('input', () => {
+    if (expense.policy === 'mileage') return;
+    expense.amount = parseNumber(amountInput.value);
+    persistAndRefresh(expense);
+  });
+
+  mealType.addEventListener('change', () => {
+    expense.mealType = mealType.value;
+    persistAndRefresh(expense);
+  });
+
+  receipt.addEventListener('change', () => {
+    expense.hasReceipt = receipt.checked;
+    persistAndRefresh(expense);
+  });
+
+  milesInput.addEventListener('input', () => {
+    expense.miles = parseNumber(milesInput.value);
+    expense.amount = expense.miles * IRS_RATE;
+    amountInput.value = expense.amount ? expense.amount.toFixed(2) : '';
+    persistAndRefresh(expense);
+  });
+
+  travelCategory.addEventListener('change', () => {
+    expense.travelCategory = travelCategory.value;
+    updateFlightFieldsVisibility(expense, refs);
+    persistAndRefresh(expense);
+  });
+
+  travelClass.addEventListener('change', () => {
+    expense.travelClass = travelClass.value;
+    persistAndRefresh(expense);
+  });
+
+  flightHours.addEventListener('input', () => {
+    expense.flightHours = flightHours.value;
+    persistAndRefresh(expense);
+  });
+
+  removeBtn.addEventListener('click', () => {
+    removeExpense(expense.id);
+  });
+
+  applyExpenseType(expense, refs);
+  return row;
+};
+
+const addExpense = (initial = {}) => {
+  const baseType = EXPENSE_TYPES[0];
+  const expense = {
+    id: uuid(),
+    date: '',
+    type: baseType.value,
+    account: baseType.account,
+    description: '',
+    payment: 'personal',
+    amount: 0,
+    reimbursable: 0,
+    hasReceipt: true,
+    mealType: 'dinner',
+    miles: 0,
+    travelCategory: 'air_domestic',
+    travelClass: 'coach',
+    flightHours: '',
+    ...initial,
+  };
+
+  state.expenses.push(expense);
+  const row = buildRow(expense);
+  elements.expensesBody.appendChild(row);
+  evaluateExpense(expense);
+  updateRowUI(expense);
+  updateTotals();
+  updatePreview();
+  saveState(state);
+};
+
+const restoreExpenses = () => {
+  if (!state.expenses.length) {
+    addExpense();
+    return;
+  }
+
+  state.expenses.forEach((expense) => {
+    if (!expense.id) expense.id = uuid();
+    const row = buildRow(expense);
+    elements.expensesBody.appendChild(row);
+    evaluateExpense(expense);
+    updateRowUI(expense);
+  });
+
+  updateTotals();
+  updatePreview();
+};
+
+const copyPreview = async () => {
+  if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+    elements.copyFeedback.textContent = 'Clipboard unavailable. Select the text and copy manually.';
+    setTimeout(() => { elements.copyFeedback.textContent = ''; }, 3000);
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(elements.reportPreview.value);
+    elements.copyFeedback.textContent = 'Copied to clipboard!';
+  } catch (error) {
+    console.warn('Copy to clipboard failed', error);
+    elements.copyFeedback.textContent = 'Unable to copy automatically. Select and copy manually.';
+  }
+
+  setTimeout(() => { elements.copyFeedback.textContent = ''; }, 3000);
+};
+
+const initHeaderBindings = () => bindHeaderFields();
+
+const initAddButton = () => {
+  elements.addExpense?.addEventListener('click', () => addExpense());
+};
+
+const initCopyButton = () => {
+  elements.copyPreview?.addEventListener('click', copyPreview);
+};
+
+const refreshAllExpenses = () => {
+  state.expenses.forEach((expense) => {
+    evaluateExpense(expense);
+    updateRowUI(expense);
+  });
+  updateTotals();
+  updatePreview();
+};
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    refreshAllExpenses();
+  }
+});
+
+const init = () => {
+  initHeaderBindings();
+  restoreExpenses();
+  initAddButton();
+  initCopyButton();
+};
+
+init();

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,46 @@
+import { STORAGE_KEY, cloneDefaultState, DEFAULT_STATE } from './constants.js';
+
+const getLocalStorage = () => {
+  try {
+    if (typeof window === 'undefined' || !('localStorage' in window)) {
+      return null;
+    }
+    const testKey = '__fsi-expense-test__';
+    window.localStorage.setItem(testKey, 'ok');
+    window.localStorage.removeItem(testKey);
+    return window.localStorage;
+  } catch (error) {
+    console.warn('Local storage unavailable, state will not persist.', error);
+    return null;
+  }
+};
+
+const storage = getLocalStorage();
+
+export const loadState = () => {
+  if (!storage) {
+    return cloneDefaultState();
+  }
+
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return cloneDefaultState();
+    const parsed = JSON.parse(raw);
+    return {
+      header: { ...DEFAULT_STATE.header, ...(parsed.header || {}) },
+      expenses: Array.isArray(parsed.expenses) ? parsed.expenses : [],
+    };
+  } catch (error) {
+    console.warn('Unable to load saved expense state', error);
+    return cloneDefaultState();
+  }
+};
+
+export const saveState = (state) => {
+  if (!storage) return;
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('Unable to persist expense state', error);
+  }
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,17 @@
+export const fmtCurrency = (value) => {
+  const amount = Number.isFinite(value) ? value : 0;
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+};
+
+export const parseNumber = (value) => {
+  if (value === '' || value === null || value === undefined) return 0;
+  const num = Number(value);
+  return Number.isNaN(num) ? 0 : num;
+};
+
+export const uuid = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `id-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 10)}`;
+};

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,345 @@
+:root {
+  --bg: #0b1120;
+  --card: #111c34;
+  --fg: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --warning: #f97316;
+}
+
+* {
+  box-sizing: border-box;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 20px 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+header .logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.8), rgba(14, 116, 144, 0.8));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+header h1 {
+  margin: 0 0 6px;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.2rem);
+}
+
+header .tagline {
+  margin: 0;
+  color: var(--muted);
+  max-width: 620px;
+}
+
+main {
+  width: min(1120px, 95vw);
+  margin: 0 auto 48px;
+  padding: 24px 0 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+input,
+select,
+textarea,
+button {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--fg);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+button {
+  cursor: pointer;
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.4);
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+button:hover {
+  background: rgba(56, 189, 248, 0.25);
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 70px;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox input {
+  width: auto;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.card-header button {
+  flex-shrink: 0;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 820px;
+}
+
+thead th {
+  text-align: left;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+tbody td {
+  padding: 12px 10px;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.expense-row input,
+.expense-row select,
+.expense-row textarea {
+  width: 100%;
+}
+
+.expense-row textarea {
+  min-height: 72px;
+}
+
+.detail {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  display: grid;
+  gap: 12px;
+}
+
+.detail[hidden] {
+  display: none;
+}
+
+.detail label {
+  font-size: 0.85rem;
+}
+
+.detail .hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.expense-account {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.expense-reimbursable {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.policy-messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.policy-messages li {
+  font-size: 0.85rem;
+  border-left: 3px solid transparent;
+  padding-left: 8px;
+}
+
+.policy-messages li.warning {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.policy-messages li.info {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.remove-expense {
+  background: transparent;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: #fca5a5;
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+
+.remove-expense:hover {
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.remove-expense:active {
+  transform: scale(0.96);
+}
+
+.totals {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0;
+}
+
+.totals div {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.totals dt {
+  margin: 0 0 4px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+}
+
+.totals dd {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+#reportPreview {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  min-height: 200px;
+}
+
+.copy-feedback {
+  height: 1.2rem;
+  margin-top: 6px;
+  color: var(--muted);
+}
+
+input.readonly {
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--muted);
+}
+
+@media (max-width: 860px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  header .logo {
+    width: 48px;
+    height: 48px;
+  }
+
+  table {
+    min-width: 720px;
+  }
+}
+
+@media (max-width: 600px) {
+  main {
+    width: 100%;
+    padding-inline: 16px;
+  }
+
+  .card {
+    padding: 18px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone expense report builder page with policy guidance and dynamic expense rows
- implement client-side storage, validation, and reporting logic for mileage, travel, and meal rules
- document how to run the app locally for manual verification

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68deb765051c8333b852719a131cbc2d