### PR TITLE
Add Docker packaging and document Google Cloud deployment pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Exclude Git metadata and GitHub workflows
+.git
+.github
+
+# Exclude local development files
+node_modules
+npm-debug.log
+
+# Exclude macOS/Linux temporary files
+.DS_Store
+*.swp

--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -1,52 +1,20 @@
-# This workflow will build a docker container, publish it to Google Container
-# Registry, and deploy it to GKE when there is a push to the "main"
-# branch.
-#
-# To configure this workflow:
-#
-# 1. Enable the following Google Cloud APIs:
-#
-#    - Artifact Registry (artifactregistry.googleapis.com)
-#    - Google Kubernetes Engine (container.googleapis.com)
-#    - IAM Credentials API (iamcredentials.googleapis.com)
-#
-#    You can learn more about enabling APIs at
-#    https://support.google.com/googleapi/answer/6158841.
-#
-# 2. Ensure that your repository contains the necessary configuration for your
-#    Google Kubernetes Engine cluster, including deployment.yml,
-#    kustomization.yml, service.yml, etc.
-#
-# 3. Create and configure a Workload Identity Provider for GitHub:
-#    https://github.com/google-github-actions/auth#preferred-direct-workload-identity-federation.
-#
-#    Depending on how you authenticate, you will need to grant an IAM principal
-#    permissions on Google Cloud:
-#
-#    - Artifact Registry Administrator (roles/artifactregistry.admin)
-#    - Kubernetes Engine Developer (roles/container.developer)
-#
-#    You can learn more about setting IAM permissions at
-#    https://cloud.google.com/iam/docs/manage-access-other-resources
-#
-# 5. Change the values in the "env" block to match your values.
-
 name: 'Build and Deploy to GKE'
 
 on:
   push:
     branches:
-      - '"main"'
+      - 'main'
 
 env:
-  PROJECT_ID: 'my-project' # TODO: update to your Google Cloud project ID
-  GAR_LOCATION: 'us-central1' # TODO: update to your region
-  GKE_CLUSTER: 'cluster-1' # TODO: update to your cluster name
-  GKE_ZONE: 'us-central1-c' # TODO: update to your cluster zone
-  DEPLOYMENT_NAME: 'gke-test' # TODO: update to your deployment name
-  REPOSITORY: 'samples' # TODO: update to your Artifact Registry docker repository name
-  IMAGE: 'static-site'
-  WORKLOAD_IDENTITY_PROVIDER: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider' # TODO: update to your workload identity provider
+  PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GAR_LOCATION: ${{ vars.GAR_LOCATION }}
+  GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
+  GKE_LOCATION: ${{ vars.GKE_LOCATION }}
+  DEPLOYMENT_NAME: ${{ vars.GKE_DEPLOYMENT_NAME }}
+  REPOSITORY: ${{ vars.GAR_REPOSITORY }}
+  IMAGE: 'expenses-web'
+  WORKLOAD_IDENTITY_PROVIDER: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
 jobs:
   setup-build-publish-deploy:
@@ -62,17 +30,13 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
 
-      # Configure Workload Identity Federation and generate an access token.
-      #
-      # See https://github.com/google-github-actions/auth for more options,
-      # including authenticating via a JSON credentials file.
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@f112390a2df9932162083945e46d439060d66ec2' # google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ env.SERVICE_ACCOUNT }}'
 
-      # Authenticate Docker to Google Cloud Artifact Registry
       - name: 'Docker Auth'
         uses: 'docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567' # docker/login-action@v3
         with:
@@ -80,37 +44,38 @@ jobs:
           password: '${{ steps.auth.outputs.auth_token }}'
           registry: '${{ env.GAR_LOCATION }}-docker.pkg.dev'
 
-      # Get the GKE credentials so we can deploy to the cluster
       - name: 'Set up GKE credentials'
         uses: 'google-github-actions/get-gke-credentials@6051de21ad50fbb1767bc93c11357a49082ad116' # google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: '${{ env.GKE_CLUSTER }}'
-          location: '${{ env.GKE_ZONE }}'
+          location: '${{ env.GKE_LOCATION }}'
 
-      # Build the Docker image
       - name: 'Build and push Docker container'
+        env:
+          DOCKER_TAG: ${{ format('{0}-docker.pkg.dev/{1}/{2}/{3}:{4}', env.GAR_LOCATION, env.PROJECT_ID, env.REPOSITORY, env.IMAGE, github.sha) }}
         run: |-
-          DOCKER_TAG="${GAR_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/${IMAGE}:${GITHUB_SHA}"
-
           docker build \
-            --tag "${DOCKER_TAG}" \
+            --tag "$DOCKER_TAG" \
             --build-arg GITHUB_SHA="${GITHUB_SHA}" \
             --build-arg GITHUB_REF="${GITHUB_REF}" \
             .
 
-          docker push "${DOCKER_TAG}"
+          docker push "$DOCKER_TAG"
 
-      # Set up kustomize
       - name: 'Set up Kustomize'
         run: |-
-          curl -sfLo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.4.3/kustomize_v5.4.3_linux_amd64.tar.gz
-          chmod u+x ./kustomize
+          curl -sSL -o kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.4.3/kustomize_v5.4.3_linux_amd64.tar.gz
+          tar -xzf kustomize.tar.gz
+          mv kustomize $GITHUB_WORKSPACE/kustomize
+          chmod +x $GITHUB_WORKSPACE/kustomize
+          rm kustomize.tar.gz
 
-      # Deploy the Docker image to the GKE cluster
       - name: 'Deploy to GKE'
+        env:
+          DOCKER_TAG: ${{ format('{0}-docker.pkg.dev/{1}/{2}/{3}:{4}', env.GAR_LOCATION, env.PROJECT_ID, env.REPOSITORY, env.IMAGE, github.sha) }}
         run: |-
-          # replacing the image name in the k8s template
-          ./kustomize edit set image LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/IMAGE:TAG=$GAR_LOCATION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE:$GITHUB_SHA
-          ./kustomize build . | kubectl apply -f -
-          kubectl rollout status deployment/$DEPLOYMENT_NAME
+          cd k8s
+          ../kustomize edit set image LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/IMAGE:TAG=$DOCKER_TAG
+          ../kustomize build . | kubectl apply -f -
+          kubectl rollout status deployment/${{ env.DEPLOYMENT_NAME }}
           kubectl get services -o wide

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.27-alpine
+
+# Copy static assets into the nginx public directory.
+COPY index.html /usr/share/nginx/html/index.html
+COPY styles.css /usr/share/nginx/html/styles.css
+COPY manifest.webmanifest /usr/share/nginx/html/manifest.webmanifest
+COPY src /usr/share/nginx/html/src
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -14,3 +14,66 @@ A lightweight web application for preparing Freight Services expense reports wit
 3. Copy the generated preview text into the company expense template when you are done.
 
 Local storage persistence is optional; if the browser disables access, the app still functions without saving state between sessions.
+
+## Container image
+
+The application can be packaged as a lightweight NGINX container by using the included `Dockerfile`.
+
+Build and run locally:
+
+```bash
+docker build -t expenses-web:local .
+docker run --rm -p 8080:80 expenses-web:local
+```
+
+The site will be served at http://localhost:8080.
+
+## Google Cloud deployment pipeline
+
+This repository contains a GitHub Actions workflow (`.github/workflows/google.yml`) that builds the Docker image, pushes it to Google Artifact Registry, and deploys the container to Google Kubernetes Engine (GKE) using the manifests in the `k8s/` directory.
+
+### One-time Google Cloud setup
+
+1. **Enable required APIs** in your Google Cloud project:
+   - Artifact Registry (`artifactregistry.googleapis.com`)
+   - Google Kubernetes Engine (`container.googleapis.com`)
+   - IAM Credentials API (`iamcredentials.googleapis.com`)
+2. **Create infrastructure** (replace names with your preferred values):
+   - Create an Artifact Registry *Docker* repository, e.g. `expenses` in region `us-central1`.
+   - Create or reuse a GKE cluster (zonal or regional) capable of running public web workloads.
+3. **Create a dedicated service account** (for example `github-actions@<PROJECT_ID>.iam.gserviceaccount.com`) and grant it the following roles:
+   - `roles/artifactregistry.writer`
+   - `roles/container.developer`
+4. **Configure Workload Identity Federation** so GitHub can impersonate the service account without long-lived keys:
+   - Create a Workload Identity Pool and Provider following the [google-github-actions/auth documentation](https://github.com/google-github-actions/auth#setting-up-workload-identity-federation).
+   - Authorize the provider to impersonate the service account you created in step 3.
+5. **Capture the identifiers** you will need for the workflow:
+   - Google Cloud project ID (e.g. `my-expenses-project`)
+   - Artifact Registry location (e.g. `us-central1`)
+   - Artifact Registry repository name (e.g. `expenses`)
+   - GKE cluster name (e.g. `expenses-cluster`)
+   - GKE cluster location (zone or region, e.g. `us-central1-c`)
+   - Kubernetes deployment name (matches the metadata name in `k8s/deployment.yaml`, default `expenses-web`)
+   - Workload Identity Provider resource path (e.g. `projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>`)
+   - Service account email (created in step 3)
+
+### GitHub configuration
+
+Add the following **repository variables** (Settings → Secrets and variables → Actions → Variables) so the workflow picks up your project-specific values without editing the workflow file:
+
+| Variable name | Example value |
+| ------------- | ------------- |
+| `GCP_PROJECT_ID` | `my-expenses-project` |
+| `GAR_LOCATION` | `us-central1` |
+| `GAR_REPOSITORY` | `expenses` |
+| `GKE_CLUSTER` | `expenses-cluster` |
+| `GKE_LOCATION` | `us-central1-c` |
+| `GKE_DEPLOYMENT_NAME` | `expenses-web` |
+| `WORKLOAD_IDENTITY_PROVIDER` | `projects/123456789/locations/global/workloadIdentityPools/github/providers/expenses` |
+| `WIF_SERVICE_ACCOUNT` | `github-actions@my-expenses-project.iam.gserviceaccount.com` |
+
+> **Note:** GitHub repository *variables* are appropriate here because the values are not secrets. Use repository *secrets* instead if you prefer to keep the identifiers private.
+
+Once the variables are in place, pushes to the `main` branch will trigger the workflow to build the image, push it to Artifact Registry, and deploy the new version to your cluster using the manifests in `k8s/`.
+
+You can inspect or customize the Kubernetes manifests under `k8s/` to tune replica counts, resource requests/limits, or service type.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: expenses-web
+  labels:
+    app: expenses-web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: expenses-web
+  template:
+    metadata:
+      labels:
+        app: expenses-web
+    spec:
+      containers:
+        - name: web
+          image: LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/IMAGE:TAG
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+images:
+  - name: LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/IMAGE
+    newTag: TAG

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: expenses-web
+  labels:
+    app: expenses-web
+spec:
+  type: LoadBalancer
+  selector:
+    app: expenses-web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
- add a Dockerfile and Kubernetes manifests so the static site can be containerized and deployed
- update the Google Cloud GitHub Actions workflow to use repository variables and apply the kustomize manifests
- document Docker usage and the Google Cloud setup requirements in the README

## Testing
- `docker build -t expenses-web:local .` *(fails: Docker CLI not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_b_68debbea7d1483339bc3564bc9888086