### PR TITLE
Add offline caching service worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY index.html /usr/share/nginx/html/index.html
 COPY styles.css /usr/share/nginx/html/styles.css
 COPY manifest.webmanifest /usr/share/nginx/html/manifest.webmanifest
 COPY src /usr/share/nginx/html/src
+COPY service-worker.js /usr/share/nginx/html/service-worker.js
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A lightweight web application for preparing Freight Services expense reports wit
 - Inline policy reminders for travel, meals, and mileage reimbursements.
 - Automatic reimbursement calculations for capped categories and mileage at the IRS rate.
 - Copy-ready text preview that mirrors the official expense form layout.
+- Offline-ready experience once the site has been loaded at least once while online.
 
 ## Getting started
 1. Serve the project with any static HTTP server (for example `python -m http.server 8000`).
@@ -27,6 +28,10 @@ docker run --rm -p 8080:80 expenses-web:local
 ```
 
 The site will be served at http://localhost:8080.
+
+## Offline support
+
+The application registers a service worker that precaches the core HTML, CSS, JavaScript, and manifest assets. Load the site once while online so the service worker can install; subsequent visits (or reloads) will continue to work even without a network connection, using the cached assets for requests.
 
 ## Google Cloud deployment pipeline
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,69 @@
+const CACHE_VERSION = 'expenses-cache-v1';
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/manifest.webmanifest',
+  '/src/constants.js',
+  '/src/main.js',
+  '/src/storage.js',
+  '/src/utils.js',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_VERSION)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestURL = new URL(event.request.url);
+  if (requestURL.origin !== self.location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((networkResponse) => {
+          if (
+            !networkResponse ||
+            networkResponse.status !== 200 ||
+            networkResponse.type !== 'basic'
+          ) {
+            return networkResponse;
+          }
+
+          const responseToCache = networkResponse.clone();
+          caches.open(CACHE_VERSION).then((cache) => {
+            cache.put(event.request, responseToCache);
+          });
+
+          return networkResponse;
+        })
+        .catch(() => caches.match('/index.html'));
+    })
+  );
+});

--- a/src/main.js
+++ b/src/main.js
@@ -515,3 +515,11 @@ const init = () => {
 };
 
 init();
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('/service-worker.js')
+    .catch((error) => {
+      console.error('Service worker registration failed:', error);
+    });
+}


### PR DESCRIPTION
## Summary
- add a service worker that precaches the core HTML, CSS, JS, and manifest assets
- register the service worker from the main bundle and ship it with the container image
- document the new offline capability in the project README

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_b_68decf96767483339cc1bd617e3052c0