### PR TITLE
Ensure nginx container listens on Cloud Run port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM nginx:1.27-alpine
 
+ENV PORT=8080
+
+# Replace the default server configuration so we can control the listen port
+# through the PORT environment variable expected by Cloud Run and other PaaS
+# platforms.
+RUN rm -f /etc/nginx/conf.d/default.conf
+COPY docker/configure-nginx.sh /docker-entrypoint.d/10-configure-nginx.sh
+RUN chmod +x /docker-entrypoint.d/10-configure-nginx.sh
+
 # Copy static assets into the nginx public directory.
 COPY index.html /usr/share/nginx/html/index.html
 COPY styles.css /usr/share/nginx/html/styles.css
@@ -7,6 +16,6 @@ COPY manifest.webmanifest /usr/share/nginx/html/manifest.webmanifest
 COPY src /usr/share/nginx/html/src
 COPY service-worker.js /usr/share/nginx/html/service-worker.js
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Local storage persistence is optional; if the browser disables access, the app s
 
 ## Container image
 
-The application can be packaged as a lightweight NGINX container by using the included `Dockerfile`.
+The application can be packaged as a lightweight NGINX container by using the included `Dockerfile`. The container listens on the `PORT` environment variable (default `8080`), making it compatible with platforms like Google Cloud Run.
 
 Build and run locally:
 
 ```bash
 docker build -t expenses-web:local .
-docker run --rm -p 8080:80 expenses-web:local
+docker run --rm -p 8080:8080 expenses-web:local
 ```
 
 The site will be served at http://localhost:8080.

--- a/docker/configure-nginx.sh
+++ b/docker/configure-nginx.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+PORT="${PORT:-8080}"
+
+cat <<CONFIG >/etc/nginx/conf.d/default.conf
+server {
+    listen       ${PORT};
+    listen  [::]:${PORT};
+    server_name  _;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    location / {
+        try_files \$uri /index.html =404;
+    }
+
+    # Service workers should not be aggressively cached to ensure updates roll out.
+    location = /service-worker.js {
+        add_header Cache-Control "no-store";
+    }
+}
+CONFIG


### PR DESCRIPTION
## Summary
- adjust the nginx-based Docker image to generate a server config that listens on the PORT environment variable expected by Cloud Run
- add a startup script that writes the nginx configuration at container boot
- document the Cloud Run compatibility and updated local run instructions in the README

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68ded2fadad883339566a114b2b60c28