### PR TITLE
Fix Kubernetes manifests to expose NGINX on correct port

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - name: web
           image: LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/IMAGE:TAG
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           resources:
             requests:
               cpu: 50m
@@ -29,12 +29,12 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -11,4 +11,4 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 8080


### PR DESCRIPTION
## Summary
- update the deployment manifest to expose container port 8080 and probe the correct port
- align the service targetPort with the container's 8080 listener so traffic reaches NGINX

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_b_68ded45514f88333aa092128d63fa1df