### PR TITLE
Ensure new logo loads with refreshed service worker cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,9 +1,10 @@
-const CACHE_VERSION = 'expenses-cache-v1';
+const CACHE_VERSION = 'expenses-cache-v2';
 const PRECACHE_URLS = [
   '/',
   '/index.html',
   '/styles.css',
   '/manifest.webmanifest',
+  '/fsi-logo.png',
   '/src/constants.js',
   '/src/main.js',
   '/src/storage.js',


### PR DESCRIPTION
## Summary
- bump the service worker cache version so clients fetch the updated branding assets
- add the new logo image to the precache list to guarantee it is refreshed and available offline

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_b_68ded705b67483338076c7d5305e1201