### PR TITLE
Add authenticated admin reporting portal

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>FSI Expense Reports – Admin</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    body {
+      background: #f4f7fb;
+      color: #1f2933;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 0;
+      padding: 0;
+    }
+
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    main {
+      margin: 2rem auto;
+      max-width: 720px;
+      padding: 0 1rem 3rem;
+    }
+
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+      padding: 1.75rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .card h2 {
+      margin-top: 0;
+      font-size: 1.25rem;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      font-weight: 600;
+      font-size: 0.95rem;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    input, textarea, select, button {
+      font: inherit;
+    }
+
+    input[type="text"],
+    input[type="password"],
+    input[type="date"],
+    textarea {
+      border: 1px solid #d0d7e2;
+      border-radius: 8px;
+      padding: 0.6rem 0.75rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      background: #fff;
+    }
+
+    input:focus,
+    textarea:focus,
+    select:focus {
+      border-color: #2563eb;
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+    }
+
+    button {
+      background: #2563eb;
+      border: none;
+      border-radius: 999px;
+      color: #fff;
+      cursor: pointer;
+      font-weight: 600;
+      padding: 0.65rem 1.5rem;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    button.secondary {
+      background: #fff;
+      color: #1f2933;
+      border: 1px solid #d0d7e2;
+    }
+
+    button.secondary:not([disabled]):hover {
+      box-shadow: 0 6px 14px rgba(15, 23, 42, 0.15);
+    }
+
+    button[disabled] {
+      opacity: 0.6;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    button:not([disabled]):hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .hint {
+      color: #52606d;
+      font-size: 0.9rem;
+      margin-top: -0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .status {
+      border-radius: 8px;
+      font-size: 0.9rem;
+      margin-top: 1rem;
+      padding: 0.75rem 1rem;
+    }
+
+    .status.error {
+      background: rgba(220, 38, 38, 0.1);
+      color: #991b1b;
+    }
+
+    .status.success {
+      background: rgba(22, 163, 74, 0.1);
+      color: #166534;
+    }
+
+    .status.info {
+      background: rgba(37, 99, 235, 0.1);
+      color: #1d4ed8;
+    }
+
+    .grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    .hidden {
+      display: none !important;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Finance Admin Console</h1>
+    <p id="adminUser" class="hint" style="color: rgba(255,255,255,0.85);"></p>
+  </header>
+  <main>
+    <section class="card" id="loginCard">
+      <h2>Sign in</h2>
+      <form id="loginForm" novalidate>
+        <label>Username
+          <input id="loginUsername" name="username" type="text" autocomplete="username" required />
+        </label>
+        <label>Password
+          <input id="loginPassword" name="password" type="password" autocomplete="current-password" required />
+        </label>
+        <div class="actions">
+          <button type="submit" id="loginSubmit">Sign in</button>
+          <span class="hint">Only finance administrators with CFO or super-user roles may access exports.</span>
+        </div>
+      </form>
+      <div id="loginStatus" class="status hidden" role="status" aria-live="polite"></div>
+    </section>
+
+    <section class="card hidden" id="exportCard">
+      <h2>Download expense reports</h2>
+      <p class="hint">Select the reporting window and optionally restrict the export to specific employee email addresses.</p>
+      <form id="exportForm" class="grid" novalidate>
+        <label>Start date
+          <input id="startDate" type="date" required />
+        </label>
+        <label>End date
+          <input id="endDate" type="date" required />
+        </label>
+        <label style="grid-column: 1 / -1;">Employee emails (optional)
+          <textarea id="employeeFilter" rows="3" placeholder="one-per-line or comma separated"></textarea>
+        </label>
+        <div class="actions" style="grid-column: 1 / -1;">
+          <button type="submit" id="downloadBtn">Download reports</button>
+          <button type="button" id="logoutBtn" class="secondary">Sign out</button>
+        </div>
+      </form>
+      <div id="exportStatus" class="status hidden" role="status" aria-live="polite"></div>
+    </section>
+  </main>
+  <script type="module" src="/src/admin.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "fsi-expense-report",
       "version": "1.0.0",
       "devDependencies": {
+        "@types/supertest": "^2.0.16",
+        "fflate": "^0.8.1",
+        "supertest": "^6.3.4",
         "vitest": "^0.34.6"
       }
     },
@@ -422,6 +425,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
@@ -754,10 +780,24 @@
         "@types/chai": "<5.2.0"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -769,6 +809,29 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.13.0"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.16.tgz",
+      "integrity": "sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/superagent": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -883,6 +946,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -893,6 +963,13 @@
         "node": "*"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -901,6 +978,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -935,10 +1043,40 @@
         "node": "*"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
     },
@@ -973,6 +1111,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -981,6 +1140,70 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1022,6 +1245,53 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1037,6 +1307,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -1045,6 +1325,100 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/local-pkg": {
@@ -1078,6 +1452,62 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mlly": {
@@ -1124,6 +1554,29 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/p-limit": {
@@ -1229,6 +1682,22 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -1278,6 +1747,95 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1320,6 +1878,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/tinybench": {
@@ -1551,6 +2147,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "test": "vitest"
   },
   "devDependencies": {
+    "@types/supertest": "^2.0.16",
+    "fflate": "^0.8.1",
+    "supertest": "^6.3.4",
     "vitest": "^0.34.6"
   }
 }

--- a/server/README.md
+++ b/server/README.md
@@ -17,6 +17,7 @@ Create a `.env` file alongside `package.json` with the following keys:
 | `PORT` | No | Port used by the HTTP server (defaults to `3000`). |
 | `DATABASE_URL` | Yes | PostgreSQL connection string used by Prisma. Example: `postgresql://postgres:postgres@localhost:5432/expenses?schema=public`. |
 | `API_KEY` | Yes | Shared secret token that clients must provide in the `x-api-key` header when creating reports. |
+| `ADMIN_JWT_SECRET` | Yes | Secret string used to sign administrator session cookies. Use a long, random value. |
 
 ## Available scripts
 
@@ -42,6 +43,48 @@ npm run prisma:migrate
 # Apply migrations in production environments
 npm run prisma:deploy
 ```
+
+## Admin authentication
+
+The server exposes administrator endpoints under `/api/admin/*` and an SPA at `/admin` for finance users. Authentication uses
+HTTP-only JWT cookies signed with `ADMIN_JWT_SECRET`. Only users with the `CFO` or `SUPER` roles can access the export APIs.
+
+- `POST /api/admin/login` &ndash; accepts `{ "username": "...", "password": "..." }`, validates the credentials, and creates an
+  eight-hour session cookie.
+- `POST /api/admin/logout` &ndash; clears the active session.
+- `GET /api/admin/session` &ndash; returns the authenticated user's profile, enforcing the CFO/super role requirement.
+- `GET /api/admin/reports` &ndash; streams a ZIP archive containing `reports.csv` and `expenses.csv` for the requested date range.
+
+### Provisioning administrator accounts
+
+Administrator credentials are stored in the `admin_users` table. Usernames are persisted in lowercase so that sign-ins are
+case-insensitive. To create an account, hash the password with `bcryptjs` and insert the record using Prisma or SQL. The
+following script illustrates the Prisma approach:
+
+```bash
+cd server
+node --env-file=.env <<'NODE'
+import bcrypt from 'bcryptjs';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const username = 'cfo';
+const password = 'SuperSecret!1';
+const passwordHash = await bcrypt.hash(password, 12);
+
+await prisma.adminUser.upsert({
+  where: { username },
+  update: { passwordHash, role: 'CFO' },
+  create: { username, passwordHash, role: 'CFO' }
+});
+
+console.log('Provisioned admin user');
+await prisma.$disconnect();
+NODE
+```
+
+Alternatively, run the same logic in a seed script or migration. Ensure that passwords are rotated periodically and stored
+securely.
 
 ## Database migrations
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,13 +9,21 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^5.9.1",
+        "archiver": "^6.0.2",
+        "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.6",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "helmet": "^7.0.0",
+        "jsonwebtoken": "^9.0.2",
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@types/archiver": "^5.3.4",
+        "@types/bcryptjs": "^2.4.6",
+        "@types/cookie-parser": "^1.4.7",
         "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^20.10.5",
         "prisma": "^5.9.1",
         "ts-node-dev": "^2.0.0",
@@ -159,6 +167,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/archiver": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.3.4.tgz",
+      "integrity": "sha512-Lj7fLBIMwYFgViVVZHEdExZC3lVYsl+QL0VmdNdIzGZH544jHveYWij6qdnBgJQDnR7pMKliN9z2cPZFEbhyPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -178,6 +203,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/express": {
@@ -213,10 +248,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -243,6 +296,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
@@ -334,6 +397,82 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.2.tgz",
+      "integrity": "sha512-UQ/2nW7NMl1G+1UnrLypQw1VdT9XZg/ECcKPq7l+STzStrSivFIXIp34D8M5zeNGW5NoOupdYCHv6VySCPNNlw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
+      "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^8.0.0",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -347,11 +486,42 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.7.0.tgz",
+      "integrity": "sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
@@ -414,6 +584,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -485,6 +670,21 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.3.tgz",
+      "integrity": "sha512-/UIcLWvwAQyVibgpQDPtfNM3SvqN7G9elAPAV7GM0L53EbNWwWiCsWtK8Fwed/APEbptPHXs5PuW+y8Bq8lFTA==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^5.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -522,11 +722,64 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.1.tgz",
+      "integrity": "sha512-lO1dFui+CEUh/ztYIpgpKItKW9Bb4NWakCRJrnqAbFIYD+OZAwb2VfD5T5eXMw2FNcsDHkQcNl/Wh3iVXYwU6g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -609,6 +862,15 @@
         "xtend": "^4.0.0"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -669,6 +931,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -714,6 +985,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -768,7 +1045,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -879,6 +1155,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -945,7 +1227,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -1028,6 +1309,151 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1160,7 +1586,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1194,7 +1619,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1265,6 +1689,12 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1315,6 +1745,50 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -1390,6 +1864,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -1553,6 +2039,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -1584,6 +2090,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/to-regex-range": {
@@ -1753,6 +2279,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1782,7 +2314,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/xtend": {
@@ -1803,6 +2334,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.2.tgz",
+      "integrity": "sha512-LfOdrUvPB8ZoXtvOBz6DlNClfvi//b5d56mSWyJi7XbH/HfhOHfUhOqxhT/rUiR7yiktlunqRo+jY6y/cWC/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "compress-commons": "^5.0.1",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/zod": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,13 +13,21 @@
   },
   "dependencies": {
     "@prisma/client": "^5.9.1",
+    "archiver": "^6.0.2",
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/archiver": "^5.3.4",
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cookie-parser": "^1.4.7",
+    "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.10.5",
     "prisma": "^5.9.1",
     "ts-node-dev": "^2.0.0",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -41,3 +41,20 @@ model Expense {
   @@map("expenses")
   @@index([reportId], map: "expenses_report_id_idx")
 }
+
+enum AdminRole {
+  CFO
+  SUPER
+  ANALYST
+}
+
+model AdminUser {
+  id           String    @id @default(cuid())
+  username     String    @unique
+  passwordHash String    @map("password_hash")
+  role         AdminRole @default(ANALYST)
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  @@map("admin_users")
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,12 @@
 import express from 'express';
 import helmet from 'helmet';
+import cookieParser from 'cookie-parser';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import reportsRouter from './routes/reports.js';
+import adminAuthRouter from './routes/adminAuth.js';
+import adminReportsRouter from './routes/adminReports.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -12,12 +15,52 @@ const __dirname = path.dirname(__filename);
 const app = express();
 
 app.use(helmet());
+app.use(cookieParser());
 app.use(express.json({ limit: '1mb' }));
 
-const publicDir = path.resolve(__dirname, '../../public');
-app.use(express.static(publicDir));
+const rootDir = path.resolve(__dirname, '../../');
+const publicDir = path.join(rootDir, 'public');
+const adminHtmlPath = path.join(rootDir, 'admin.html');
+const adminScriptPath = path.join(rootDir, 'src', 'admin.js');
+
+if (fs.existsSync(publicDir)) {
+  app.use(express.static(publicDir));
+}
 
 app.use('/api/reports', reportsRouter);
+app.use('/api/admin', adminAuthRouter);
+app.use('/api/admin/reports', adminReportsRouter);
+
+const noCacheHeaders = {
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache'
+} as const;
+
+app.get('/admin', (req, res, next) => {
+  if (!fs.existsSync(adminHtmlPath)) {
+    return res.status(404).json({ message: 'Admin SPA not found' });
+  }
+
+  res.set(noCacheHeaders);
+  res.sendFile(adminHtmlPath, (err) => {
+    if (err) {
+      next(err);
+    }
+  });
+});
+
+app.get('/src/admin.js', (req, res, next) => {
+  if (!fs.existsSync(adminScriptPath)) {
+    return res.status(404).json({ message: 'Admin script not found' });
+  }
+
+  res.set(noCacheHeaders);
+  res.sendFile(adminScriptPath, (err) => {
+    if (err) {
+      next(err);
+    }
+  });
+});
 
 app.get('*', (req, res, next) => {
   const indexFile = path.join(publicDir, 'index.html');

--- a/server/src/middleware/adminAuth.ts
+++ b/server/src/middleware/adminAuth.ts
@@ -1,0 +1,135 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { AdminRole, AdminUser } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+import { prisma } from '../lib/prisma.js';
+
+export type SessionUser = Pick<AdminUser, 'id' | 'username' | 'role'>;
+
+const AUTH_COOKIE_NAME = 'admin_session';
+const SESSION_MAX_AGE_MS = 1000 * 60 * 60 * 8; // 8 hours
+const allowedRoles: AdminRole[] = ['CFO', 'SUPER'];
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    adminUser?: SessionUser;
+  }
+}
+
+interface JwtPayload {
+  sub: string;
+  role: AdminRole;
+  iat: number;
+  exp: number;
+}
+
+function cookieOptions(withMaxAge: boolean) {
+  return {
+    httpOnly: true,
+    sameSite: 'strict' as const,
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    ...(withMaxAge ? { maxAge: SESSION_MAX_AGE_MS } : {})
+  };
+}
+
+function getJwtSecret(): string {
+  const secret = process.env.ADMIN_JWT_SECRET;
+
+  if (!secret) {
+    throw new Error('ADMIN_JWT_SECRET is not configured');
+  }
+
+  return secret;
+}
+
+function decodeToken(token: string): JwtPayload | undefined {
+  try {
+    return jwt.verify(token, getJwtSecret()) as JwtPayload;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+async function loadAdminFromToken(
+  req: Request,
+  res: Response
+): Promise<SessionUser | undefined> {
+  const token = req.cookies?.[AUTH_COOKIE_NAME];
+
+  if (!token) {
+    return undefined;
+  }
+
+  const payload = decodeToken(token);
+
+  if (!payload) {
+    clearAdminSession(res);
+    return undefined;
+  }
+
+  const user = await prisma.adminUser.findUnique({ where: { id: payload.sub } });
+
+  if (!user) {
+    clearAdminSession(res);
+    return undefined;
+  }
+
+  const sessionUser: SessionUser = {
+    id: user.id,
+    username: user.username,
+    role: user.role
+  };
+
+  req.adminUser = sessionUser;
+  return sessionUser;
+}
+
+export async function ensureAdminSession(
+  req: Request,
+  res: Response
+): Promise<SessionUser | undefined> {
+  if (req.adminUser) {
+    return req.adminUser;
+  }
+
+  return loadAdminFromToken(req, res);
+}
+
+export function requireAdmin(
+  roles: AdminRole[] = allowedRoles
+) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const user = await ensureAdminSession(req, res);
+
+      if (!user) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      if (!roles.includes(user.role)) {
+        return res.status(403).json({ message: 'Insufficient role' });
+      }
+
+      return next();
+    } catch (error) {
+      return next(error);
+    }
+  };
+}
+
+export function createAdminSession(res: Response, user: SessionUser) {
+  const token = jwt.sign(
+    { sub: user.id, role: user.role },
+    getJwtSecret(),
+    { expiresIn: Math.floor(SESSION_MAX_AGE_MS / 1000) }
+  );
+
+  res.cookie(AUTH_COOKIE_NAME, token, cookieOptions(true));
+}
+
+export function clearAdminSession(res: Response) {
+  res.clearCookie(AUTH_COOKIE_NAME, cookieOptions(false));
+}
+
+export const adminSessionCookieName = AUTH_COOKIE_NAME;
+export const adminAllowedRoles = allowedRoles;

--- a/server/src/routes/adminAuth.ts
+++ b/server/src/routes/adminAuth.ts
@@ -1,0 +1,78 @@
+import { Router } from 'express';
+import bcrypt from 'bcryptjs';
+import { z } from 'zod';
+import { prisma } from '../lib/prisma.js';
+import {
+  clearAdminSession,
+  createAdminSession,
+  ensureAdminSession,
+  requireAdmin
+} from '../middleware/adminAuth.js';
+
+const router = Router();
+
+const loginSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1)
+});
+
+router.post('/login', async (req, res, next) => {
+  const parsed = loginSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: 'Invalid login payload',
+      issues: parsed.error.flatten()
+    });
+  }
+
+  const username = parsed.data.username.trim().toLowerCase();
+  const password = parsed.data.password;
+
+  try {
+    const user = await prisma.adminUser.findUnique({ where: { username } });
+
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const passwordMatches = await bcrypt.compare(password, user.passwordHash);
+
+    if (!passwordMatches) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const sessionUser = {
+      id: user.id,
+      username: user.username,
+      role: user.role
+    } as const;
+
+    createAdminSession(res, sessionUser);
+
+    return res.status(200).json({ user: sessionUser });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/logout', requireAdmin(), (req, res) => {
+  clearAdminSession(res);
+  return res.status(204).end();
+});
+
+router.get('/session', requireAdmin(), async (req, res, next) => {
+  try {
+    const user = await ensureAdminSession(req, res);
+
+    if (!user) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    return res.json({ user });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+export default router;

--- a/server/src/routes/adminReports.ts
+++ b/server/src/routes/adminReports.ts
@@ -1,0 +1,183 @@
+import { Router } from 'express';
+import archiver from 'archiver';
+import { z } from 'zod';
+import { prisma } from '../lib/prisma.js';
+import { requireAdmin } from '../middleware/adminAuth.js';
+
+const router = Router();
+
+const querySchema = z
+  .object({
+    start: z.string().min(1),
+    end: z.string().min(1),
+    employees: z.union([z.string(), z.array(z.string())]).optional()
+  })
+  .transform((value) => {
+    const startDate = new Date(value.start);
+    const endDate = new Date(value.end);
+
+    if (Number.isNaN(startDate.getTime())) {
+      throw new Error('Invalid start date');
+    }
+
+    if (Number.isNaN(endDate.getTime())) {
+      throw new Error('Invalid end date');
+    }
+
+    const employeesRaw = value.employees;
+    const employees = Array.isArray(employeesRaw)
+      ? employeesRaw
+      : typeof employeesRaw === 'string'
+      ? employeesRaw.split(',')
+      : [];
+
+    const normalizedEmployees = employees
+      .map((employee) => employee.trim().toLowerCase())
+      .filter(Boolean);
+
+    return {
+      start: startDate,
+      end: endDate,
+      employees: normalizedEmployees.length > 0 ? normalizedEmployees : undefined
+    };
+  });
+
+function csvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const stringValue = String(value);
+
+  if (/[",\n]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+}
+
+router.get('/', requireAdmin(), async (req, res, next) => {
+  let parsed;
+  try {
+    parsed = querySchema.parse(req.query);
+  } catch (error) {
+    return res.status(400).json({ message: error instanceof Error ? error.message : 'Invalid query' });
+  }
+
+  if (parsed.start > parsed.end) {
+    return res.status(400).json({ message: 'Start date must be before or equal to end date' });
+  }
+
+  try {
+    const reports = await prisma.report.findMany({
+      where: {
+        finalizedAt: {
+          gte: parsed.start,
+          lte: parsed.end
+        },
+        ...(parsed.employees
+          ? {
+              employeeEmail: {
+                in: parsed.employees
+              }
+            }
+          : {})
+      },
+      include: {
+        expenses: {
+          orderBy: { incurredAt: 'asc' }
+        }
+      },
+      orderBy: { finalizedAt: 'asc' }
+    });
+
+    const archive = archiver('zip', { zlib: { level: 9 } });
+
+    archive.on('error', (error: Error) => {
+      next(error);
+    });
+
+    const startLabel = parsed.start.toISOString().slice(0, 10);
+    const endLabel = parsed.end.toISOString().slice(0, 10);
+    const filename = `reports_${startLabel}_${endLabel}.zip`;
+
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Cache-Control', 'no-store');
+
+    archive.pipe(res);
+
+    const reportLines = [
+      [
+        'report_id',
+        'employee_email',
+        'finalized_at',
+        'finalized_year',
+        'finalized_month',
+        'finalized_week',
+        'header_json',
+        'totals_json'
+      ].join(',')
+    ];
+
+    const expenseLines = [
+      [
+        'report_id',
+        'expense_id',
+        'external_id',
+        'category',
+        'description',
+        'amount',
+        'currency',
+        'incurred_at',
+        'metadata_json'
+      ].join(',')
+    ];
+
+    for (const report of reports) {
+      reportLines.push(
+        [
+          csvValue(report.reportId),
+          csvValue(report.employeeEmail.toLowerCase()),
+          csvValue(report.finalizedAt.toISOString()),
+          csvValue(report.finalizedYear),
+          csvValue(report.finalizedMonth),
+          csvValue(report.finalizedWeek),
+          csvValue(report.header ? JSON.stringify(report.header) : ''),
+          csvValue(report.totals ? JSON.stringify(report.totals) : '')
+        ].join(',')
+      );
+
+      for (const expense of report.expenses) {
+        const metadataRaw =
+          expense.metadata === null || typeof expense.metadata === 'undefined'
+            ? ''
+            : JSON.stringify(expense.metadata);
+        const metadataValue = metadataRaw === 'null' ? '' : metadataRaw;
+
+        expenseLines.push(
+          [
+            csvValue(report.reportId),
+            csvValue(expense.id),
+            csvValue(expense.externalId ?? ''),
+            csvValue(expense.category),
+            csvValue(expense.description ?? ''),
+            csvValue(expense.amount.toString()),
+            csvValue(expense.currency),
+            csvValue(expense.incurredAt ? expense.incurredAt.toISOString() : ''),
+            csvValue(metadataValue)
+          ].join(',')
+        );
+      }
+    }
+
+    archive.append(reportLines.join('\n'), { name: 'reports.csv' });
+    archive.append(expenseLines.join('\n'), { name: 'expenses.csv' });
+
+    await archive.finalize();
+  } catch (error) {
+    return next(error);
+  }
+});
+
+export default router;

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -20,7 +20,7 @@ router.post('/', authenticate, async (req, res, next) => {
 
   const reportData: Prisma.ReportCreateInput = {
     reportId: data.reportId,
-    employeeEmail: data.employeeEmail,
+    employeeEmail: data.employeeEmail.toLowerCase(),
     finalizedAt: data.finalizedAt,
     finalizedYear: data.period.year,
     finalizedMonth: data.period.month,

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,0 +1,237 @@
+const loginForm = document.querySelector('#loginForm');
+const loginCard = document.querySelector('#loginCard');
+const loginStatus = document.querySelector('#loginStatus');
+const loginSubmit = document.querySelector('#loginSubmit');
+const exportCard = document.querySelector('#exportCard');
+const exportForm = document.querySelector('#exportForm');
+const downloadBtn = document.querySelector('#downloadBtn');
+const exportStatus = document.querySelector('#exportStatus');
+const logoutBtn = document.querySelector('#logoutBtn');
+const adminUserLabel = document.querySelector('#adminUser');
+const startDateInput = document.querySelector('#startDate');
+const endDateInput = document.querySelector('#endDate');
+const employeeFilterInput = document.querySelector('#employeeFilter');
+
+const statusClasses = {
+  success: 'success',
+  error: 'error',
+  info: 'info'
+};
+
+function showStatus(element, message, type = 'info') {
+  element.textContent = message;
+  element.classList.remove('hidden', statusClasses.success, statusClasses.error, statusClasses.info);
+  element.classList.add(statusClasses[type] ?? statusClasses.info);
+}
+
+function hideStatus(element) {
+  element.textContent = '';
+  element.classList.add('hidden');
+  element.classList.remove(statusClasses.success, statusClasses.error, statusClasses.info);
+}
+
+function setAuthenticated(user) {
+  loginCard.classList.add('hidden');
+  exportCard.classList.remove('hidden');
+  adminUserLabel.textContent = `Signed in as ${user.username} (${user.role})`;
+  hideStatus(loginStatus);
+}
+
+function setLoggedOut(message) {
+  loginCard.classList.remove('hidden');
+  exportCard.classList.add('hidden');
+  adminUserLabel.textContent = '';
+  if (message) {
+    showStatus(loginStatus, message, 'info');
+  } else {
+    hideStatus(loginStatus);
+  }
+  hideStatus(exportStatus);
+}
+
+function parseEmployees(value) {
+  return value
+    .split(/\n|,/)
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function defaultDateRange() {
+  const today = new Date();
+  const start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+  const end = new Date(today);
+
+  const isoStart = start.toISOString().slice(0, 10);
+  const isoEnd = end.toISOString().slice(0, 10);
+
+  startDateInput.value = isoStart;
+  endDateInput.value = isoEnd;
+}
+
+async function fetchSession() {
+  try {
+    const response = await fetch('/api/admin/session', {
+      credentials: 'include',
+      headers: { 'accept': 'application/json' }
+    });
+
+    if (!response.ok) {
+      setLoggedOut();
+      return;
+    }
+
+    const body = await response.json();
+    if (body?.user) {
+      setAuthenticated(body.user);
+    } else {
+      setLoggedOut();
+    }
+  } catch (error) {
+    console.error(error);
+    setLoggedOut('Unable to verify session. Please sign in again.');
+  }
+}
+
+loginForm?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  hideStatus(loginStatus);
+
+  const formData = new FormData(loginForm);
+  const username = (formData.get('username') ?? '').toString().trim();
+  const password = (formData.get('password') ?? '').toString();
+
+  if (!username || !password) {
+    showStatus(loginStatus, 'Username and password are required.', 'error');
+    return;
+  }
+
+  loginSubmit.disabled = true;
+
+  try {
+    const response = await fetch('/api/admin/login', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const message = body?.message || 'Unable to sign in.';
+      showStatus(loginStatus, message, 'error');
+      return;
+    }
+
+    const body = await response.json();
+    if (body?.user) {
+      setAuthenticated(body.user);
+      defaultDateRange();
+      loginForm.reset();
+    }
+  } catch (error) {
+    console.error(error);
+    showStatus(loginStatus, 'Unexpected error while signing in.', 'error');
+  } finally {
+    loginSubmit.disabled = false;
+  }
+});
+
+logoutBtn?.addEventListener('click', async () => {
+  hideStatus(exportStatus);
+  downloadBtn.disabled = false;
+
+  try {
+    const response = await fetch('/api/admin/logout', {
+      method: 'POST',
+      credentials: 'include'
+    });
+
+    if (!response.ok && response.status !== 204) {
+      showStatus(exportStatus, 'Sign out failed. Please try again.', 'error');
+      return;
+    }
+
+    setLoggedOut('You have been signed out.');
+  } catch (error) {
+    console.error(error);
+    showStatus(exportStatus, 'Network error while signing out.', 'error');
+  }
+});
+
+function filenameFromHeaders(response, fallback) {
+  const disposition = response.headers.get('content-disposition');
+  if (!disposition) {
+    return fallback;
+  }
+
+  const match = disposition.match(/filename="?([^";]+)"?/i);
+  if (match?.[1]) {
+    return match[1];
+  }
+
+  return fallback;
+}
+
+exportForm?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  hideStatus(exportStatus);
+
+  const start = startDateInput.value;
+  const end = endDateInput.value;
+
+  if (!start || !end) {
+    showStatus(exportStatus, 'Start and end dates are required.', 'error');
+    return;
+  }
+
+  if (new Date(start) > new Date(end)) {
+    showStatus(exportStatus, 'Start date must be before the end date.', 'error');
+    return;
+  }
+
+  const employees = parseEmployees(employeeFilterInput.value);
+
+  const params = new URLSearchParams({ start, end });
+  for (const employee of employees) {
+    params.append('employees', employee);
+  }
+
+  downloadBtn.disabled = true;
+  showStatus(exportStatus, 'Preparing download…', 'info');
+
+  try {
+    const response = await fetch(`/api/admin/reports?${params.toString()}`, {
+      method: 'GET',
+      credentials: 'include'
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const message = body?.message || 'Export failed. Check your session and filters.';
+      showStatus(exportStatus, message, 'error');
+      return;
+    }
+
+    const blob = await response.blob();
+    const filename = filenameFromHeaders(response, `reports_${start}_${end}.zip`);
+
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+
+    showStatus(exportStatus, 'Export generated successfully.', 'success');
+  } catch (error) {
+    console.error(error);
+    showStatus(exportStatus, 'Unexpected error while generating export.', 'error');
+  } finally {
+    downloadBtn.disabled = false;
+  }
+});
+
+defaultDateRange();
+fetchSession();

--- a/tests/adminApi.test.ts
+++ b/tests/adminApi.test.ts
@@ -1,0 +1,224 @@
+import { Buffer } from 'node:buffer';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { unzipSync } from 'fflate';
+
+const adminUserFindUnique = vi.fn();
+const reportFindMany = vi.fn();
+
+vi.mock('../server/src/lib/prisma.js', () => ({
+  prisma: {
+    adminUser: {
+      findUnique: adminUserFindUnique
+    },
+    report: {
+      findMany: reportFindMany
+    }
+  }
+}));
+
+const importApp = async () => {
+  const module = await import('../server/src/app.ts');
+  return module.default;
+};
+
+const hashedPassword = '$2a$10$6szdT0Ir.ksjzE5K0e90gePHGWhfsB5hugPuhPghsrPc7hiDhinCm';
+
+function binaryParser(res, callback) {
+  res.setEncoding('binary');
+  const chunks: Buffer[] = [];
+  res.on('data', (chunk) => chunks.push(Buffer.from(chunk, 'binary')));
+  res.on('end', () => callback(null, Buffer.concat(chunks)));
+}
+
+describe('admin authentication and exports', () => {
+  beforeEach(() => {
+    process.env.ADMIN_JWT_SECRET = 'test-secret';
+    adminUserFindUnique.mockReset();
+    reportFindMany.mockReset();
+  });
+
+  it('rejects report exports without a valid session', async () => {
+    const app = await importApp();
+
+    const response = await request(app)
+      .get('/api/admin/reports')
+      .query({ start: '2024-01-01', end: '2024-01-31' });
+
+    expect(response.status).toBe(401);
+    expect(reportFindMany).not.toHaveBeenCalled();
+  });
+
+  it('logs in a CFO user and returns the active session', async () => {
+    const app = await importApp();
+
+    const adminRecord = {
+      id: 'admin-1',
+      username: 'cfo',
+      passwordHash: hashedPassword,
+      role: 'CFO'
+    };
+
+    adminUserFindUnique.mockImplementation(async ({ where }) => {
+      if ('username' in where && where.username === 'cfo') {
+        return adminRecord;
+      }
+
+      if ('id' in where && where.id === 'admin-1') {
+        return adminRecord;
+      }
+
+      return null;
+    });
+
+    const loginResponse = await request(app)
+      .post('/api/admin/login')
+      .send({ username: 'CFO', password: 'SuperSecret!1' });
+
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.body.user).toMatchObject({ username: 'cfo', role: 'CFO' });
+    const [cookie] = loginResponse.get('set-cookie');
+    expect(cookie).toContain('admin_session');
+
+    const sessionResponse = await request(app)
+      .get('/api/admin/session')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(sessionResponse.body.user).toMatchObject({ username: 'cfo', role: 'CFO' });
+  });
+
+  it('prevents non-privileged roles from downloading exports', async () => {
+    const app = await importApp();
+
+    const analystRecord = {
+      id: 'admin-2',
+      username: 'analyst',
+      passwordHash: hashedPassword,
+      role: 'ANALYST'
+    };
+
+    adminUserFindUnique.mockImplementation(async ({ where }) => {
+      if ('username' in where && where.username === 'analyst') {
+        return analystRecord;
+      }
+
+      if ('id' in where && where.id === 'admin-2') {
+        return analystRecord;
+      }
+
+      return null;
+    });
+
+    const loginResponse = await request(app)
+      .post('/api/admin/login')
+      .send({ username: 'analyst', password: 'SuperSecret!1' });
+
+    expect(loginResponse.status).toBe(200);
+
+    const [cookie] = loginResponse.get('set-cookie');
+    expect(cookie).toBeDefined();
+
+    const exportResponse = await request(app)
+      .get('/api/admin/reports')
+      .set('Cookie', cookie)
+      .query({ start: '2024-02-01', end: '2024-02-28' });
+
+    expect(exportResponse.status).toBe(403);
+    expect(reportFindMany).not.toHaveBeenCalled();
+  });
+
+  it('streams a ZIP archive containing CSV exports for the requested range', async () => {
+    const app = await importApp();
+
+    const adminRecord = {
+      id: 'admin-9',
+      username: 'finance-chief',
+      passwordHash: hashedPassword,
+      role: 'CFO'
+    };
+
+    adminUserFindUnique.mockImplementation(async ({ where }) => {
+      if ('username' in where && where.username === 'finance-chief') {
+        return adminRecord;
+      }
+
+      if ('id' in where && where.id === 'admin-9') {
+        return adminRecord;
+      }
+
+      return null;
+    });
+
+    reportFindMany.mockResolvedValue([
+      {
+        reportId: 'rep-123',
+        employeeEmail: 'Employee@example.com',
+        finalizedAt: new Date('2024-03-05T12:00:00Z'),
+        finalizedYear: 2024,
+        finalizedMonth: 3,
+        finalizedWeek: 10,
+        header: { department: 'Logistics' },
+        totals: { submitted: 250.75 },
+        expenses: [
+          {
+            id: 'exp-1',
+            reportId: 'rep-123',
+            externalId: null,
+            category: 'travel',
+            description: 'Airfare',
+            amount: { toString: () => '150.25' },
+            currency: 'USD',
+            incurredAt: new Date('2024-03-01T00:00:00Z'),
+            metadata: { payment: 'company' }
+          },
+          {
+            id: 'exp-2',
+            reportId: 'rep-123',
+            externalId: 'CC-42',
+            category: 'meals',
+            description: 'Client dinner',
+            amount: { toString: () => '100.50' },
+            currency: 'USD',
+            incurredAt: null,
+            metadata: null
+          }
+        ]
+      }
+    ]);
+
+    const loginResponse = await request(app)
+      .post('/api/admin/login')
+      .send({ username: 'Finance-Chief', password: 'SuperSecret!1' });
+
+    const [cookie] = loginResponse.get('set-cookie');
+
+    const exportResponse = await request(app)
+      .get('/api/admin/reports')
+      .set('Cookie', cookie)
+      .query({
+        start: '2024-03-01',
+        end: '2024-03-31',
+        employees: 'employee@example.com'
+      })
+      .buffer()
+      .parse(binaryParser)
+      .expect(200);
+
+    expect(exportResponse.headers['content-type']).toBe('application/zip');
+
+    const zipEntries = unzipSync(new Uint8Array(exportResponse.body));
+    const reportsCsv = new TextDecoder().decode(zipEntries['reports.csv']);
+    const expensesCsv = new TextDecoder().decode(zipEntries['expenses.csv']);
+
+    expect(reportsCsv).toContain('rep-123');
+    expect(reportsCsv).toContain('employee@example.com');
+    expect(expensesCsv).toContain('exp-1');
+    expect(expensesCsv).toContain('Airfare');
+
+    const callArgs = reportFindMany.mock.calls.at(-1)?.[0];
+    expect(callArgs?.where?.finalizedAt?.gte.toISOString()).toBe(new Date('2024-03-01').toISOString());
+    expect(callArgs?.where?.finalizedAt?.lte.toISOString()).toBe(new Date('2024-03-31').toISOString());
+    expect(callArgs?.where?.employeeEmail?.in).toEqual(['employee@example.com']);
+  });
+});


### PR DESCRIPTION
## Summary
- add an admin SPA served without caching for finance workflows
- implement JWT-backed admin authentication and protected CSV export routes
- document admin provisioning steps and cover login/export flows with integration tests

## Testing
- npx vitest run
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dedd13bdcc833382ba3c29039e8b99