### PR TITLE
Ensure static updates invalidate cached pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ RUN chmod +x /docker-entrypoint.d/10-configure-nginx.sh
 
 # Copy static assets into the nginx public directory.
 COPY index.html /usr/share/nginx/html/index.html
+COPY admin.html /usr/share/nginx/html/admin.html
 COPY styles.css /usr/share/nginx/html/styles.css
 COPY manifest.webmanifest /usr/share/nginx/html/manifest.webmanifest
+COPY fsi-logo.png /usr/share/nginx/html/fsi-logo.png
 COPY src /usr/share/nginx/html/src
 COPY service-worker.js /usr/share/nginx/html/service-worker.js
 

--- a/docker/configure-nginx.sh
+++ b/docker/configure-nginx.sh
@@ -12,13 +12,22 @@ server {
     root   /usr/share/nginx/html;
     index  index.html;
 
+    # Static assets can be cached by browsers, but HTML should always be revalidated
+    # so that styling or layout changes deploy immediately. Split the handling into
+    # two locations so we can attach the appropriate cache headers.
+    location ~* \.(?:css|js|png|jpg|jpeg|gif|svg|webp|ico|json)$ {
+        try_files \$uri =404;
+        add_header Cache-Control "public, max-age=3600, must-revalidate" always;
+    }
+
     location / {
         try_files \$uri /index.html =404;
+        add_header Cache-Control "no-store, must-revalidate" always;
     }
 
     # Service workers should not be aggressively cached to ensure updates roll out.
     location = /service-worker.js {
-        add_header Cache-Control "no-store";
+        add_header Cache-Control "no-store" always;
     }
 }
 CONFIG

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,5 @@
-const CACHE_VERSION = 'expenses-cache-v2';
+const CACHE_VERSION = 'expenses-cache-v3';
 const PRECACHE_URLS = [
-  '/',
   '/index.html',
   '/styles.css',
   '/manifest.webmanifest',
@@ -41,6 +40,8 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  const isNavigationRequest = event.request.mode === 'navigate';
+
   event.respondWith(
     fetch(event.request)
       .then((networkResponse) => {
@@ -52,10 +53,12 @@ self.addEventListener('fetch', (event) => {
           return networkResponse;
         }
 
-        const responseToCache = networkResponse.clone();
-        caches.open(CACHE_VERSION).then((cache) => {
-          cache.put(event.request, responseToCache);
-        });
+        if (!isNavigationRequest) {
+          const responseToCache = networkResponse.clone();
+          caches.open(CACHE_VERSION).then((cache) => {
+            cache.put(event.request, responseToCache);
+          });
+        }
 
         return networkResponse;
       })
@@ -65,7 +68,7 @@ self.addEventListener('fetch', (event) => {
           return cachedResponse;
         }
 
-        if (event.request.mode === 'navigate') {
+        if (isNavigationRequest) {
           const fallback = await caches.match('/index.html');
           if (fallback) {
             return fallback;


### PR DESCRIPTION
## Summary
- add the admin shell and logo to the nginx image so the latest assets deploy together
- tweak the nginx configuration to revalidate HTML responses while keeping static caching for assets
- bump the service worker cache and avoid caching navigation requests to ensure new layouts load immediately

## Testing
- npm test *(fails: Vitest cannot resolve the optional supertest dependency in API tests)*

------
https://chatgpt.com/codex/tasks/task_b_68def7e89554833382611c00fca93a3e