### PR TITLE
Add Google Drive receipt storage provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1448,6 +1448,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@googleapis/drive": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-18.0.0.tgz",
+      "integrity": "sha512-nk4TirsHttwZSOjBEBjltCPDKUqwFso59G3WitNE+EGNVSVseSEq981f8Dmjq2ah0/fk3i206wuCU4PUCwcoTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -3696,6 +3708,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4109,6 +4130,29 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -4177,6 +4221,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -4390,6 +4446,108 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.0.tgz",
+      "integrity": "sha512-66if47It7y+Sab3HMkwEXx1kCq9qUC9px8ZXoj1CMrmLmUw81GpbnsNlXnlyZyGbGPGcj+tDD9XsZ23m7GLaJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.4.0.tgz",
+      "integrity": "sha512-CmIrSy1bqMQUsPmA9+hcSbAXL80cFhu40cGMUjCaLpNKVzzvi+0uAHq8GNZxkoGYIsTX4ZQ7e4aInAqWxgn4fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gopd": {
@@ -5039,6 +5197,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -5301,7 +5479,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6238,6 +6415,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6440,6 +6623,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -6541,6 +6733,7 @@
         "@aws-sdk/client-s3": "^3.470.0",
         "@aws-sdk/s3-request-presigner": "^3.470.0",
         "@google-cloud/storage": "^7.8.0",
+        "@googleapis/drive": "^18.0.0",
         "@prisma/client": "^5.9.1",
         "archiver": "^6.0.2",
         "bcryptjs": "^2.4.3",

--- a/server/README.md
+++ b/server/README.md
@@ -18,7 +18,7 @@ Create a `.env` file alongside `package.json` with the following keys:
 | `DATABASE_URL` | Yes | PostgreSQL connection string used by Prisma. Example: `postgresql://postgres:postgres@localhost:5432/expenses?schema=public`. |
 | `API_KEY` | Yes | Shared secret token that clients must provide in the `x-api-key` header when creating reports. |
 | `ADMIN_JWT_SECRET` | Yes | Secret string used to sign administrator session cookies. Use a long, random value. |
-| `RECEIPT_STORAGE_PROVIDER` | No | Receipt storage backend: `memory` (default), `s3`, or `gcs`. |
+| `RECEIPT_STORAGE_PROVIDER` | No | Receipt storage backend: `memory` (default), `s3`, `gcs`, or `gdrive`. |
 | `RECEIPT_MAX_BYTES` | No | Maximum allowed file size per receipt upload (defaults to 10&nbsp;MiB). |
 | `RECEIPT_MAX_FILES` | No | Maximum number of files accepted per upload request (defaults to 5). |
 | `RECEIPT_URL_TTL_SECONDS` | No | Signed URL lifetime in seconds when generating download links (defaults to 900). |
@@ -31,6 +31,9 @@ Create a `.env` file alongside `package.json` with the following keys:
 | `GCS_BUCKET` | For `gcs` | Google Cloud Storage bucket name. |
 | `GCS_RECEIPT_PREFIX` | No | Prefix under which receipts are stored (defaults to `receipts`). |
 | `GCS_PUBLIC_URL_TEMPLATE` | No | Template for constructing public URLs when signed URLs are not needed. |
+| `GDRIVE_FOLDER_ID` | For `gdrive` | Destination folder ID where receipts will be uploaded. |
+| `GDRIVE_CREDENTIALS_JSON` | No | JSON service-account credentials; if omitted, the SDK uses `GOOGLE_APPLICATION_CREDENTIALS`. |
+| `GDRIVE_SCOPES` | No | Comma-separated OAuth scopes for Drive access (defaults to `https://www.googleapis.com/auth/drive.file`). |
 
 ## Available scripts
 
@@ -115,7 +118,7 @@ Ensure the database exists before running the migration. The same `DATABASE_URL`
 
 Clients attach receipt images or PDFs through `POST /api/receipts`. Requests must include the report's draft identifier (`reportId`), the client-side expense identifier (`expenseId`), and one or more files in a multipart payload. The API validates MIME type, file count, and size before streaming each file to the configured object storage provider. Metadata (content type, checksum, storage key, etc.) is persisted in the `receipts` table and linked back to the appropriate expense once the report is finalized.
 
-By default the server keeps receipts in an in-memory sink (`RECEIPT_STORAGE_PROVIDER=memory`), which is useful for tests or local development. Configure the provider for production uploads by setting `RECEIPT_STORAGE_PROVIDER` to `s3` or `gcs` and supplying the corresponding bucket and credential environment variables noted above. The admin export generates signed download URLs using the configured storage backend.
+By default the server keeps receipts in an in-memory sink (`RECEIPT_STORAGE_PROVIDER=memory`), which is useful for tests or local development. Configure the provider for production uploads by setting `RECEIPT_STORAGE_PROVIDER` to `s3`, `gcs`, or `gdrive` and supplying the corresponding bucket/folder and credential environment variables noted above. The admin export generates signed download URLs using the configured storage backend.
 
 ## Serving the SPA
 

--- a/server/package.json
+++ b/server/package.json
@@ -12,10 +12,11 @@
     "prisma:deploy": "prisma migrate deploy"
   },
   "dependencies": {
-    "@prisma/client": "^5.9.1",
     "@aws-sdk/client-s3": "^3.470.0",
     "@aws-sdk/s3-request-presigner": "^3.470.0",
     "@google-cloud/storage": "^7.8.0",
+    "@googleapis/drive": "^18.0.0",
+    "@prisma/client": "^5.9.1",
     "archiver": "^6.0.2",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
@@ -27,12 +28,12 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/multer": "^1.4.7",
     "@types/archiver": "^5.3.4",
     "@types/bcryptjs": "^2.4.6",
     "@types/cookie-parser": "^1.4.7",
+    "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.5",
+    "@types/multer": "^1.4.7",
     "@types/node": "^20.10.5",
     "prisma": "^5.9.1",
     "ts-node-dev": "^2.0.0",


### PR DESCRIPTION
## Summary
- add a Google Drive-backed receipt storage implementation with tokenized download URLs and cache reset helper
- document Drive configuration variables and add the Drive SDK dependency
- extend receipt API tests with Google Drive success and failure scenarios

## Testing
- npm test -- --run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_b_68df0008d7708333a601e219ff09ec99