### PR TITLE
Allow configuring API endpoints via meta or global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ For a full operational handbook—including architecture notes, onboarding check
 
 Local storage persistence is optional; if the browser disables access, the app still functions without saving state between sessions.
 
+## Configuring the API endpoint
+
+By default the web client sends receipt uploads and report submissions to the same origin it was served from (for example `/api/reports`).
+When the API is hosted on a different domain or behind a reverse proxy prefix, provide the target base URL through one of the following options:
+
+- Add a meta tag to `index.html` (and `admin.html` for the finance console):
+  ```html
+  <meta name="fsi-expenses-api-base" content="https://expenses-api.example.com" />
+  ```
+- Define a global configuration object before loading `src/main.js` or `src/admin.js`:
+  ```html
+  <script>
+    window.__FSI_EXPENSES_CONFIG__ = { apiBaseUrl: 'https://expenses-api.example.com' };
+  </script>
+  ```
+
+Relative values such as `/internal/expenses-api` are also supported. If no configuration is supplied the app continues to use same-origin requests.
+
 ## Container image
 
 The application can be packaged as a lightweight NGINX container by using the included `Dockerfile`. The container listens on the `PORT` environment variable (default `8080`), making it compatible with platforms like Google Cloud Run.

--- a/admin.html
+++ b/admin.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Optional: point administrator requests to a different API origin by setting this meta tag's content. -->
+  <meta name="fsi-expenses-api-base" content="" />
   <title>FSI Expense Reports – Admin</title>
   <link rel="stylesheet" href="styles.css" />
   <style>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <!-- Optional: point submissions to a different API origin by setting this meta tag's content. -->
+  <meta name="fsi-expenses-api-base" content="" />
   <title>FSI Expense Report Builder</title>
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="stylesheet" href="styles.css" />

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,6 +4,7 @@ const PRECACHE_URLS = [
   '/styles.css',
   '/manifest.webmanifest',
   '/fsi-logo.png',
+  '/src/config.js',
   '/src/constants.js',
   '/src/main.js',
   '/src/storage.js',

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,3 +1,5 @@
+import { buildApiUrl } from './config.js';
+
 const loginForm = document.querySelector('#loginForm');
 const loginCard = document.querySelector('#loginCard');
 const loginStatus = document.querySelector('#loginStatus');
@@ -340,7 +342,7 @@ async function refreshApprovals({ suppressStatus = false } = {}) {
   });
 
   try {
-    const response = await fetch(`/api/admin/approvals?${params.toString()}`, {
+    const response = await fetch(buildApiUrl(`/api/admin/approvals?${params.toString()}`), {
       credentials: 'include',
       headers: { accept: 'application/json' }
     });
@@ -389,15 +391,18 @@ async function submitApprovalDecision(reportId, action, stage, note, triggerButt
   }
 
   try {
-    const response = await fetch(`/api/admin/approvals/${encodeURIComponent(reportId)}/decision`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'content-type': 'application/json',
-        accept: 'application/json'
-      },
-      body: JSON.stringify(payload)
-    });
+    const response = await fetch(
+      buildApiUrl(`/api/admin/approvals/${encodeURIComponent(reportId)}/decision`),
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json'
+        },
+        body: JSON.stringify(payload)
+      }
+    );
 
     if (!response.ok) {
       const body = await response.json().catch(() => ({}));
@@ -441,7 +446,7 @@ function defaultDateRange() {
 
 async function fetchSession() {
   try {
-    const response = await fetch('/api/admin/session', {
+    const response = await fetch(buildApiUrl('/api/admin/session'), {
       credentials: 'include',
       headers: { accept: 'application/json' }
     });
@@ -520,7 +525,7 @@ loginForm?.addEventListener('submit', async (event) => {
   loginSubmit.disabled = true;
 
   try {
-    const response = await fetch('/api/admin/login', {
+    const response = await fetch(buildApiUrl('/api/admin/login'), {
       method: 'POST',
       credentials: 'include',
       headers: { 'content-type': 'application/json', accept: 'application/json' },
@@ -553,7 +558,7 @@ logoutBtn?.addEventListener('click', async () => {
   if (downloadBtn) downloadBtn.disabled = false;
 
   try {
-    const response = await fetch('/api/admin/logout', {
+    const response = await fetch(buildApiUrl('/api/admin/logout'), {
       method: 'POST',
       credentials: 'include'
     });
@@ -612,7 +617,7 @@ exportForm?.addEventListener('submit', async (event) => {
   showStatus(exportStatus, 'Preparing download…', 'info');
 
   try {
-    const response = await fetch(`/api/admin/reports?${params.toString()}`, {
+    const response = await fetch(buildApiUrl(`/api/admin/reports?${params.toString()}`), {
       method: 'GET',
       credentials: 'include'
     });

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,106 @@
+const META_NAME = 'fsi-expenses-api-base';
+const LEGACY_GLOBAL_KEY = '__FSI_EXPENSES_API_BASE__';
+const GLOBAL_CONFIG_KEY = '__FSI_EXPENSES_CONFIG__';
+
+let cachedApiBase;
+
+const isString = (value) => typeof value === 'string';
+
+const readMetaApiBase = () => {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+  const meta = document.querySelector(`meta[name="${META_NAME}"]`);
+  const content = meta?.getAttribute('content');
+  return isString(content) ? content : '';
+};
+
+const readGlobalApiBase = () => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  const legacyValue = window[LEGACY_GLOBAL_KEY];
+  if (isString(legacyValue) && legacyValue.trim()) {
+    return legacyValue;
+  }
+
+  const config = window[GLOBAL_CONFIG_KEY];
+  if (config && typeof config === 'object') {
+    const candidates = [config.apiBaseUrl, config.apiBase, config.baseUrl];
+    for (const candidate of candidates) {
+      if (isString(candidate) && candidate.trim()) {
+        return candidate;
+      }
+    }
+  }
+
+  return '';
+};
+
+const sanitizeApiBase = (rawValue) => {
+  if (!isString(rawValue)) {
+    return '';
+  }
+
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      const normalizedPath = url.pathname.replace(/\/+$/, '');
+      return `${url.origin}${normalizedPath}`;
+    } catch (error) {
+      console.warn('Invalid API base URL provided, falling back to relative paths.', error);
+      return trimmed.replace(/\/+$/, '');
+    }
+  }
+
+  const withoutTrailingSlash = trimmed.replace(/\/+$/, '');
+  if (!withoutTrailingSlash) {
+    return '';
+  }
+
+  if (withoutTrailingSlash.startsWith('/')) {
+    return `/${withoutTrailingSlash.replace(/^\/+/, '')}`;
+  }
+
+  return `/${withoutTrailingSlash}`;
+};
+
+export const getApiBase = () => {
+  if (cachedApiBase !== undefined) {
+    return cachedApiBase;
+  }
+
+  const configuredBase = readMetaApiBase() || readGlobalApiBase();
+  cachedApiBase = sanitizeApiBase(configuredBase);
+  return cachedApiBase;
+};
+
+export const buildApiUrl = (path = '') => {
+  const apiBase = getApiBase();
+  if (!apiBase) {
+    return path;
+  }
+
+  if (!path) {
+    return apiBase;
+  }
+
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (/^https?:\/\//i.test(apiBase)) {
+    return `${apiBase}${normalizedPath}`;
+  }
+
+  const normalizedBase = apiBase === '/' ? '' : apiBase;
+  return `${normalizedBase}${normalizedPath}`.replace(/\/\/{2,}/g, '/');
+};

--- a/src/main.js
+++ b/src/main.js
@@ -2,11 +2,12 @@ import { EXPENSE_TYPES, IRS_RATE, MEAL_LIMITS, headerBindings } from './constant
 import { loadState, saveState, createFreshState } from './storage.js';
 import buildReportPayload, { calculateTotals } from './reportPayload.js';
 import { fmtCurrency, parseNumber, uuid } from './utils.js';
+import { buildApiUrl } from './config.js';
 
 const state = loadState();
 const expenseRows = new Map();
-const SUBMIT_ENDPOINT = '/api/reports';
-const RECEIPT_UPLOAD_ENDPOINT = '/api/receipts';
+const SUBMIT_ENDPOINT = buildApiUrl('/api/reports');
+const RECEIPT_UPLOAD_ENDPOINT = buildApiUrl('/api/receipts');
 const MAX_RECEIPT_BYTES = 10 * 1024 * 1024; // 10 MB limit per file.
 const ACCEPTED_RECEIPT_TYPES = new Set(['application/pdf']);
 const ACCEPTED_RECEIPT_PREFIXES = ['image/'];


### PR DESCRIPTION
## Summary
- add a shared configuration helper that resolves the API base URL from a meta tag or global window config
- wire the expense builder and finance admin consoles to use the helper so submissions can target a remote API origin
- update cached assets and documentation with instructions for supplying a custom API base URL

## Testing
- npm test *(fails: backend-related tests require seeded Prisma data and roles to be defined)*

------
https://chatgpt.com/codex/tasks/task_b_68df02074b7883339ee8458e1da53d7f