### PR TITLE
Add API Docker image and update deployment manifests

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,10 +15,10 @@ spec:
         app: expenses-web
     spec:
       containers:
-        - name: web
-          image: LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/IMAGE:TAG
+        - name: api
+          image: LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/expenses-api:TAG
           ports:
-            - containerPort: 8080
+            - containerPort: 3000
           resources:
             requests:
               cpu: 50m
@@ -29,12 +29,12 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 3000
             initialDelaySeconds: 30
             periodSeconds: 30

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - deployment.yaml
   - service.yaml
 images:
-  - name: LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/IMAGE
+  - name: LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY/expenses-api
     newTag: TAG

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -11,4 +11,4 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 8080
+      targetPort: 3000

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-bookworm-slim AS deps
+WORKDIR /app
+COPY server/package.json server/package-lock.json ./
+RUN npm ci
+COPY server/prisma ./prisma
+RUN npx prisma generate
+
+FROM node:20-bookworm-slim AS builder
+WORKDIR /app
+COPY server/tsconfig.json ./
+COPY server/src ./src
+COPY --from=deps /app/node_modules ./node_modules
+RUN npm run build
+
+FROM node:20-bookworm-slim AS prod-deps
+WORKDIR /app
+COPY server/package.json server/package-lock.json ./
+COPY --from=deps /app/node_modules ./node_modules
+RUN npm prune --omit=dev
+
+FROM node:20-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY server/package.json server/package-lock.json ./
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY server/prisma ./prisma
+COPY public ./public
+COPY index.html ./public/index.html
+COPY styles.css ./public/styles.css
+COPY manifest.webmanifest ./public/manifest.webmanifest
+COPY service-worker.js ./public/service-worker.js
+COPY fsi-logo.png ./public/fsi-logo.png
+COPY admin.html ./admin.html
+COPY src ./src
+COPY src ./public/src
+
+RUN chown -R node:node /app
+USER node
+
+EXPOSE 3000
+CMD ["node", "dist/index.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -60,6 +60,22 @@ npm run prisma:migrate
 npm run prisma:deploy
 ```
 
+## Container image
+
+The API can be packaged into a single container that serves both the JSON
+endpoints and the static single-page application. Build the image from the
+repository root by targeting the multi-stage Dockerfile in this workspace:
+
+```bash
+docker build -t expenses-api:local -f server/Dockerfile .
+```
+
+The resulting image exposes port `3000` and runs `node dist/index.js`. Configure
+the container by providing the environment variables documented above&mdash;at a
+minimum `DATABASE_URL`, `API_KEY`, and `ADMIN_JWT_SECRET` must be set so that the
+server can connect to PostgreSQL, authenticate report submissions, and secure
+administrator sessions.
+
 ## Admin authentication
 
 The server exposes administrator endpoints under `/api/admin/*` and an SPA at `/admin` for finance users. Authentication uses


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the API that builds the TypeScript sources, prunes dev dependencies, and bundles the SPA assets
- switch the Kubernetes deployment and service to the new Node-based image on port 3000
- document container build instructions and runtime expectations in the server README

## Testing
- npm --prefix server run prisma:generate
- npm --prefix server run build *(fails: TS2307 cannot find module '@googleapis/drive')*

------
https://chatgpt.com/codex/tasks/task_b_68df429adbb483339d33ee45724d1ea4