### PR TITLE
Add Cloud Run deployment workflow for static frontend

### DIFF
--- a/.github/workflows/cloud-run-frontend.yml
+++ b/.github/workflows/cloud-run-frontend.yml
@@ -1,0 +1,66 @@
+name: 'Build and Deploy Frontend to Cloud Run'
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GAR_LOCATION: ${{ vars.GAR_LOCATION }}
+  REPOSITORY: ${{ vars.GAR_REPOSITORY }}
+  IMAGE: 'expenses-frontend'
+  SERVICE: ${{ vars.CLOUD_RUN_SERVICE }}
+  REGION: ${{ vars.CLOUD_RUN_REGION }}
+  WORKLOAD_IDENTITY_PROVIDER: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT: ${{ vars.WIF_SERVICE_ACCOUNT }}
+
+jobs:
+  deploy-cloud-run:
+    name: 'Build, Push, and Deploy Frontend'
+    runs-on: 'ubuntu-latest'
+    environment: 'production'
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@f112390a2df9932162083945e46d439060d66ec2' # google-github-actions/auth@v2
+        with:
+          workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ env.SERVICE_ACCOUNT }}'
+
+      - name: 'Docker Auth'
+        uses: 'docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567' # docker/login-action@v3
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.auth_token }}'
+          registry: '${{ env.GAR_LOCATION }}-docker.pkg.dev'
+
+      - name: 'Build and push Docker image'
+        env:
+          DOCKER_TAG: ${{ format('{0}-docker.pkg.dev/{1}/{2}/{3}:{4}', env.GAR_LOCATION, env.PROJECT_ID, env.REPOSITORY, env.IMAGE, github.sha) }}
+        run: |-
+          docker build \
+            --tag "$DOCKER_TAG" \
+            --build-arg GITHUB_SHA="${GITHUB_SHA}" \
+            --build-arg GITHUB_REF="${GITHUB_REF}" \
+            .
+
+          docker push "$DOCKER_TAG"
+
+      - name: 'Deploy to Cloud Run'
+        uses: 'google-github-actions/deploy-cloudrun@18f650f893cf4e095ade26b85aa8b7ecabf84a1e' # google-github-actions/deploy-cloudrun@v2
+        with:
+          service: '${{ env.SERVICE }}'
+          region: '${{ env.REGION }}'
+          project_id: '${{ env.PROJECT_ID }}'
+          image: ${{ format('{0}-docker.pkg.dev/{1}/{2}/{3}:{4}', env.GAR_LOCATION, env.PROJECT_ID, env.REPOSITORY, env.IMAGE, github.sha) }}
+          allow_unauthenticated: true


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to build and deploy the static frontend to Cloud Run
- document manual Cloud Run deployment steps and required repository variables in the README
- extend the operations guide with Cloud Run automation details and clarify Google Cloud setup requirements

## Testing
- not run (documentation and CI workflow changes only)


------
https://chatgpt.com/codex/tasks/task_b_68dff0a762f083339da904409b1fd9cf