### PR TITLE
Implement expense report workflow foundation with supervisor review and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,3 +396,33 @@ the database.
 ## Architecture
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for an overview of the application's components and guidance on rebuilding the app in another stack.
+
+## Expense workflow implementation reference
+
+The expense module is built from the workbook in the repository root:
+
+- `Dave Alexander Expense Report 12.12.2023.xlsx`
+
+Use the following sheets as implementation references:
+
+- **Blank Expense Report**: Mirrors the web line-entry layout (Date, Type,
+  Account, Description, Company/Names, Amount, Receipt Link).
+- **GL Accounts**: Source for GL account search/dropdown values so each line is
+  pre-coded for NetSuite.
+- **Data List**: Source of standard expense type categories.
+
+### Expense reimbursement policy highlights used by the app
+
+- Meal receipts are required; when missing, meal reimbursement caps apply
+  (Breakfast `$10`, Lunch `$15`, Dinner `$25`).
+- Mileage reimbursement should use the IRS rate for miles beyond base commute.
+- Domestic airfare reimbursement is coach-only.
+- International airfare may use business class only for continuous flights over
+  8 hours.
+- Car rental defaults to compact class; mid-size requires multi-employee travel
+  or exception.
+- Laundry reimbursement applies only for trips longer than 7 full days.
+- Non-reimbursable categories include traffic fines, personal sundries, and
+  personal entertainment.
+- Approval path is supervisor review first, then Vice President of Operations
+  approval before final upload.

--- a/__init__.py
+++ b/__init__.py
@@ -25,18 +25,18 @@ from flask.typing import ResponseReturnValue
 from flask_session import Session as FlaskSession
 import redis as redispy
 
-from app.quote.distance import get_distance_miles
-from app.quote.theme import init_fsi_theme
+from .quote.distance import get_distance_miles
+from .quote.theme import init_fsi_theme
 from .models import db, User, Quote, HotshotRate
-from app.services.mail import (
+from .services.mail import (
     MailRateLimitError,
     enforce_mail_rate_limit,
     send_email,
     validate_sender_domain,
     user_has_mail_privileges,
 )
-from app.services.settings import reload_overrides
-from app.services.oidc_client import init_oidc_oauth
+from .services.settings import reload_overrides
+from .services.oidc_client import init_oidc_oauth
 
 login_manager = LoginManager()
 login_manager.login_view = "auth.login"
@@ -388,7 +388,7 @@ def create_app(config_class: Union[str, type] = "config.Config") -> Flask:
     init_oidc_oauth(app)
 
     # Ensure database tables exist before handling requests.
-    from app.database import (
+    from .database import (
         ensure_database_schema,
     )  # Local import avoids circular imports.
 
@@ -531,13 +531,14 @@ def create_app(config_class: Union[str, type] = "config.Config") -> Flask:
         return None
 
     # Blueprints
-    from app.api import api_bp
+    from .api import api_bp
     from .auth import auth_bp
     from .admin import admin_bp
     from .help import help_bp
-    from app.setup import setup_bp
+    from .expenses import expenses_bp
+    from .setup import setup_bp
     from .quotes import quotes_bp
-    from app.quote.admin_view import admin_quotes_bp
+    from .quote.admin_view import admin_quotes_bp
 
     csrf.exempt(api_bp)
     app.register_blueprint(api_bp, url_prefix="/api")
@@ -545,6 +546,7 @@ def create_app(config_class: Union[str, type] = "config.Config") -> Flask:
     app.register_blueprint(admin_bp, url_prefix="/admin")
     app.register_blueprint(admin_quotes_bp, url_prefix="/admin")
     app.register_blueprint(quotes_bp, url_prefix="/quotes")
+    app.register_blueprint(expenses_bp, url_prefix="/expenses")
     app.register_blueprint(help_bp, url_prefix="/help")
     app.register_blueprint(setup_bp)
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
-from app import create_app
+try:
+    from . import create_app
+except ImportError:  # pragma: no cover - direct script/module fallback
+    from __init__ import create_app
 
 __all__ = ["create_app"]

--- a/auth.py
+++ b/auth.py
@@ -546,7 +546,14 @@ def register() -> Union[str, Response]:
             flash("Invalid email address.", "warning")
             return redirect(url_for("auth.register"))
 
-        freight_employee_signup = email.endswith("@freightservices.net")
+        freight_employee_signup = email.endswith(_employee_email_suffix())
+
+        if not freight_employee_signup:
+            flash(
+                f"Registration is restricted to internal accounts ending in {_employee_email_suffix()}.",
+                "warning",
+            )
+            return redirect(url_for("auth.register"))
 
         if password != confirm_password:
             flash("Passwords do not match.", "warning")

--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ from urllib.parse import parse_qsl, quote_plus, urlencode, urlparse
 
 from sqlalchemy.engine import make_url
 
+from server_config import resolve_secret_value
+
 # Capture configuration errors so the application can start in a safe
 # maintenance mode instead of crashing during import time.
 _CONFIG_ERRORS: List[str] = []
@@ -656,7 +658,7 @@ class Config:
         "y",
     }
     MAIL_USERNAME = os.getenv("MAIL_USERNAME")
-    MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
+    MAIL_PASSWORD = resolve_secret_value("MAIL_PASSWORD", "MAIL_PASSWORD_SECRET")
     MAIL_ALLOWED_SENDER_DOMAIN = _resolve_mail_allowed_sender_domain(
         MAIL_DEFAULT_SENDER
     )
@@ -694,11 +696,21 @@ class Config:
     API_QUOTE_RATE_LIMIT = os.getenv("API_QUOTE_RATE_LIMIT", "30 per minute")
     OIDC_ISSUER = os.getenv("OIDC_ISSUER")
     OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID")
-    OIDC_CLIENT_SECRET = os.getenv("OIDC_CLIENT_SECRET")
+    OIDC_CLIENT_SECRET = resolve_secret_value(
+        "OIDC_CLIENT_SECRET", "OIDC_CLIENT_SECRET_NAME"
+    )
     OIDC_REDIRECT_URI = os.getenv("OIDC_REDIRECT_URI")
     OIDC_SCOPES = _resolve_oidc_scopes()
     OIDC_AUDIENCE = _resolve_oidc_audience()
     OIDC_ALLOWED_DOMAIN = _resolve_oidc_allowed_domain()
     OIDC_END_SESSION_ENDPOINT = os.getenv("OIDC_END_SESSION_ENDPOINT")
+    EXPENSE_RECEIPT_BUCKET = os.getenv("EXPENSE_RECEIPT_BUCKET", "").strip()
+    NETSUITE_SFTP_HOST = os.getenv("NETSUITE_SFTP_HOST", "").strip()
+    NETSUITE_SFTP_PORT = _get_int_from_env("NETSUITE_SFTP_PORT", 22)
+    NETSUITE_SFTP_USERNAME = os.getenv("NETSUITE_SFTP_USERNAME", "").strip()
+    NETSUITE_SFTP_PASSWORD = resolve_secret_value(
+        "NETSUITE_SFTP_PASSWORD", "NETSUITE_SFTP_PASSWORD_SECRET"
+    )
+    NETSUITE_SFTP_DIRECTORY = os.getenv("NETSUITE_SFTP_DIRECTORY", "/").strip()
 
     CONFIG_ERRORS = list(_CONFIG_ERRORS)

--- a/database.py
+++ b/database.py
@@ -26,6 +26,8 @@ from app.models import (
     ZipZone,
     CostZone,
     RateUpload,
+    ExpenseReport,
+    ExpenseLine,
 )
 
 
@@ -152,6 +154,8 @@ __all__ = [
     "ZipZone",
     "CostZone",
     "RateUpload",
+    "ExpenseReport",
+    "ExpenseLine",
     "ensure_database_schema",
 ]
 

--- a/expenses.py
+++ b/expenses.py
@@ -1,0 +1,265 @@
+"""Expense management routes for employee submission and supervisor review."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from io import BytesIO
+from typing import List
+
+from flask import (
+    Blueprint,
+    Response,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
+from flask_login import current_user, login_required
+
+from .models import ExpenseLine, ExpenseReport, User, db
+from .policies import employee_required, super_admin_required
+from app.services.expense_workflow import (
+    dispatch_csv_via_sftp,
+    format_pending_reports_csv,
+    load_expense_types,
+    load_gl_accounts,
+    upload_receipt_to_cloud_storage,
+)
+
+expenses_bp = Blueprint("expenses", __name__, template_folder="templates")
+
+
+@expenses_bp.route("/new", methods=["GET", "POST"])
+@login_required
+@employee_required(approved_only=True)
+def new_expense() -> str | Response:
+    """Render and process new expense report entry using dynamic line items."""
+
+    supervisors = (
+        User.query.filter(
+            User.id != current_user.id, User.role.in_(["employee", "super_admin"])
+        )
+        .order_by(User.first_name.asc(), User.last_name.asc())
+        .all()
+    )
+    gl_accounts = load_gl_accounts()
+    expense_types = load_expense_types()
+
+    if request.method == "POST":
+        supervisor_id_raw = (request.form.get("supervisor_id") or "").strip()
+        report_month_raw = (request.form.get("report_month") or "").strip()
+        notes = (request.form.get("notes") or "").strip()
+        submit_action = (request.form.get("submit_action") or "save_draft").strip()
+
+        try:
+            supervisor_id = int(supervisor_id_raw)
+        except ValueError:
+            flash("Select a valid supervisor.", "warning")
+            return redirect(url_for("expenses.new_expense"))
+
+        supervisor = User.query.get(supervisor_id)
+        if not supervisor:
+            flash("Selected supervisor was not found.", "warning")
+            return redirect(url_for("expenses.new_expense"))
+
+        try:
+            report_month = (
+                datetime.strptime(report_month_raw, "%Y-%m").date().replace(day=1)
+            )
+        except ValueError:
+            flash("Choose a valid report month.", "warning")
+            return redirect(url_for("expenses.new_expense"))
+
+        dates = request.form.getlist("line_date")
+        types = request.form.getlist("expense_type")
+        gls = request.form.getlist("gl_account")
+        vendors = request.form.getlist("vendor")
+        descriptions = request.form.getlist("description")
+        amounts = request.form.getlist("amount")
+
+        if not dates:
+            flash("Add at least one expense line.", "warning")
+            return redirect(url_for("expenses.new_expense"))
+
+        report_status = (
+            "Pending Review" if submit_action == "submit_review" else "Draft"
+        )
+        report = ExpenseReport(
+            employee_id=current_user.id,
+            supervisor_id=supervisor_id,
+            report_month=report_month,
+            notes=notes,
+            status=report_status,
+        )
+        db.session.add(report)
+        db.session.flush()
+
+        for index, line_date_raw in enumerate(dates):
+            if not line_date_raw.strip():
+                continue
+            try:
+                line_date = datetime.strptime(line_date_raw.strip(), "%Y-%m-%d").date()
+            except ValueError:
+                db.session.rollback()
+                flash(f"Line {index + 1}: invalid date.", "warning")
+                return redirect(url_for("expenses.new_expense"))
+
+            try:
+                amount = Decimal(
+                    (amounts[index] if index < len(amounts) else "0").strip()
+                )
+            except (InvalidOperation, AttributeError):
+                db.session.rollback()
+                flash(f"Line {index + 1}: amount must be numeric.", "warning")
+                return redirect(url_for("expenses.new_expense"))
+
+            receipt_file = request.files.get(f"receipt_{index}")
+            receipt_url = upload_receipt_to_cloud_storage(
+                receipt_file,
+                report_id=report.id,
+                line_index=index,
+            )
+
+            line = ExpenseLine(
+                expense_report_id=report.id,
+                date=line_date,
+                expense_type=(types[index] if index < len(types) else "").strip(),
+                gl_account=(gls[index] if index < len(gls) else "").strip(),
+                vendor=(vendors[index] if index < len(vendors) else "").strip(),
+                description=(
+                    descriptions[index] if index < len(descriptions) else ""
+                ).strip(),
+                amount=amount,
+                receipt_url=receipt_url,
+            )
+            db.session.add(line)
+
+        db.session.commit()
+        flash("Expense report saved.", "success")
+        return redirect(url_for("expenses.my_reports"))
+
+    return render_template(
+        "expenses/new_expense.html",
+        supervisors=supervisors,
+        gl_accounts=gl_accounts,
+        expense_types=expense_types,
+        reference_workbook="Dave Alexander Expense Report 12.12.2023.xlsx",
+    )
+
+
+@expenses_bp.route("/mine")
+@login_required
+@employee_required(approved_only=True)
+def my_reports() -> str:
+    """List reports submitted by the currently authenticated employee."""
+
+    reports = (
+        ExpenseReport.query.filter_by(employee_id=current_user.id)
+        .order_by(ExpenseReport.created_at.desc())
+        .all()
+    )
+    return render_template("expenses/my_reports.html", reports=reports)
+
+
+@expenses_bp.route("/supervisor")
+@login_required
+@employee_required(approved_only=True)
+def supervisor_dashboard() -> str:
+    """Show only reports awaiting review by the logged-in supervisor."""
+
+    reports = (
+        ExpenseReport.query.filter_by(
+            supervisor_id=current_user.id, status="Pending Review"
+        )
+        .order_by(ExpenseReport.created_at.asc())
+        .all()
+    )
+    return render_template("expenses/supervisor_dashboard.html", reports=reports)
+
+
+@expenses_bp.route("/supervisor/report/<int:report_id>", methods=["GET", "POST"])
+@login_required
+@employee_required(approved_only=True)
+def review_report(report_id: int) -> str | Response:
+    """Allow supervisors to approve/reject pending reports with comments."""
+
+    report = ExpenseReport.query.get_or_404(report_id)
+    if report.supervisor_id != current_user.id:
+        flash("You are not assigned to this report.", "danger")
+        return redirect(url_for("expenses.supervisor_dashboard"))
+
+    if request.method == "POST":
+        action = (request.form.get("action") or "").strip().lower()
+        comment = (request.form.get("comment") or "").strip()
+
+        if action == "reject" and not comment:
+            flash("Rejection comment is required.", "warning")
+            return redirect(url_for("expenses.review_report", report_id=report_id))
+
+        if action == "approve":
+            report.status = "Pending Upload"
+            report.rejection_comment = None
+            flash("Report approved and queued for NetSuite upload.", "success")
+        elif action == "reject":
+            report.status = "Draft"
+            report.rejection_comment = comment
+            flash("Report rejected and returned to employee draft status.", "info")
+        else:
+            flash("Select a valid review action.", "warning")
+            return redirect(url_for("expenses.review_report", report_id=report_id))
+
+        db.session.add(report)
+        db.session.commit()
+        return redirect(url_for("expenses.supervisor_dashboard"))
+
+    return render_template("expenses/review_report.html", report=report)
+
+
+@expenses_bp.route("/export/pending-upload.csv")
+@login_required
+@super_admin_required
+def export_pending_upload_csv() -> Response:
+    """Export all reports in ``Pending Upload`` status into one CSV file."""
+
+    reports = (
+        ExpenseReport.query.filter_by(status="Pending Upload")
+        .order_by(ExpenseReport.id.asc())
+        .all()
+    )
+    payload = format_pending_reports_csv(reports)
+    return send_file(
+        BytesIO(payload.encode("utf-8")),
+        mimetype="text/csv",
+        as_attachment=True,
+        download_name="netsuite-expense-upload.csv",
+    )
+
+
+@expenses_bp.route("/dispatch", methods=["POST"])
+@login_required
+@super_admin_required
+def dispatch_pending_uploads() -> Response:
+    """Send ``Pending Upload`` reports via SFTP and mark them as completed."""
+
+    reports = ExpenseReport.query.filter_by(status="Pending Upload").all()
+    if not reports:
+        flash("No reports are waiting for upload.", "info")
+        return redirect(url_for("expenses.supervisor_dashboard"))
+
+    payload = format_pending_reports_csv(reports)
+    filename = f"netsuite-expenses-{date.today().isoformat()}.csv"
+    dispatch_csv_via_sftp(payload, filename=filename)
+
+    for report in reports:
+        report.status = "Completed"
+        db.session.add(report)
+    db.session.commit()
+
+    flash(
+        f"Dispatched {len(reports)} reports to NetSuite and marked completed.",
+        "success",
+    )
+    return redirect(url_for("expenses.supervisor_dashboard"))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-Limiter==3.5.1
 folium>=0.16
 geopy>=2.4
 google-cloud-secret-manager==2.24.0
+google-cloud-storage==2.18.2
 gunicorn==22.0.0
 hypercorn>=0.15.0
 h2>=4.0.0
@@ -27,3 +28,5 @@ redis>=5
 
 Flask-Session==0.5.0
 celery==5.3.1
+
+paramiko==3.4.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,6 +54,12 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('admin_quotes.quotes_html') }}">Quotes</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('expenses.new_expense') }}">New Expense</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('expenses.supervisor_dashboard') }}">Pending Review</a>
+            </li>
             {% endif %}
             <li class="nav-item dropdown">
               <a

--- a/templates/expenses/my_reports.html
+++ b/templates/expenses/my_reports.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}My Expense Reports{% endblock %}
+{% block content %}
+<h1 class="h3">My Expense Reports</h1>
+<a class="btn btn-primary mb-3" href="{{ url_for('expenses.new_expense') }}">Create Report</a>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead><tr><th>ID</th><th>Month</th><th>Status</th><th>Supervisor</th><th>Updated</th></tr></thead>
+    <tbody>
+      {% for report in reports %}
+      <tr>
+        <td>{{ report.id }}</td>
+        <td>{{ report.report_month.strftime('%Y-%m') }}</td>
+        <td>{{ report.status }}</td>
+        <td>{{ report.supervisor.first_name or report.supervisor.email }}</td>
+        <td>{{ report.updated_at.strftime('%Y-%m-%d %H:%M') }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="5" class="text-muted">No reports yet.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/expenses/new_expense.html
+++ b/templates/expenses/new_expense.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+{% block title %}New Expense Report{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3 mb-0">New Expense Report</h1>
+  <a class="btn btn-outline-secondary" href="{{ url_for('expenses.my_reports') }}">My Reports</a>
+</div>
+<p class="text-muted">Reference workbook: <strong>{{ reference_workbook }}</strong> (Blank Expense Report, GL Accounts, Data List).</p>
+<form method="post" enctype="multipart/form-data" id="expense-form">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  <div class="row g-3 mb-3">
+    <div class="col-md-4">
+      <label class="form-label">Report Month</label>
+      <input type="month" name="report_month" class="form-control" required />
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Supervisor</label>
+      <select class="form-select" name="supervisor_id" required>
+        <option value="">Select supervisor</option>
+        {% for supervisor in supervisors %}
+        <option value="{{ supervisor.id }}">{{ supervisor.first_name or '' }} {{ supervisor.last_name or supervisor.email }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Notes</label>
+      <input name="notes" class="form-control" maxlength="255" />
+    </div>
+  </div>
+
+  <div class="table-responsive">
+    <table class="table table-bordered align-middle" id="expense-lines-table">
+      <thead class="table-light">
+        <tr>
+          <th>Date</th><th>Type</th><th>Account</th><th>Description</th><th>Company/Names</th><th>Amount</th><th>Receipt</th><th></th>
+        </tr>
+      </thead>
+      <tbody id="expense-lines"></tbody>
+    </table>
+  </div>
+
+  <button type="button" class="btn btn-outline-primary" id="add-line-btn">Add Line</button>
+  <div class="mt-3 d-flex gap-2">
+    <button class="btn btn-secondary" name="submit_action" value="save_draft">Save Draft</button>
+    <button class="btn btn-primary" name="submit_action" value="submit_review">Submit for Review</button>
+  </div>
+</form>
+
+<datalist id="gl-account-options">
+  {% for option in gl_accounts %}
+  <option value="{{ option.account }}">{{ option.label }}</option>
+  {% endfor %}
+</datalist>
+
+<template id="expense-row-template">
+  <tr>
+    <td><input type="date" class="form-control" name="line_date" required /></td>
+    <td>
+      <select class="form-select" name="expense_type" required>
+        <option value="">Select type</option>
+        {% for expense_type in expense_types %}
+        <option value="{{ expense_type }}">{{ expense_type }}</option>
+        {% endfor %}
+      </select>
+    </td>
+    <td><input class="form-control" name="gl_account" list="gl-account-options" placeholder="52070" required /></td>
+    <td><input class="form-control" name="description" maxlength="255" /></td>
+    <td><input class="form-control" name="vendor" maxlength="255" required /></td>
+    <td><input type="number" class="form-control" name="amount" min="0" step="0.01" required /></td>
+    <td><input type="file" class="form-control" accept="image/*,.pdf" /></td>
+    <td><button type="button" class="btn btn-sm btn-outline-danger remove-line-btn">Remove</button></td>
+  </tr>
+</template>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const tableBody = document.getElementById("expense-lines");
+    const template = document.getElementById("expense-row-template");
+    const addButton = document.getElementById("add-line-btn");
+
+    const renameReceiptInputs = () => {
+      tableBody.querySelectorAll("tr").forEach((row, index) => {
+        const fileInput = row.querySelector('input[type="file"]');
+        if (fileInput) {
+          fileInput.name = `receipt_${index}`;
+        }
+      });
+    };
+
+    const addLine = () => {
+      const fragment = template.content.cloneNode(true);
+      const row = fragment.querySelector("tr");
+      row.querySelector(".remove-line-btn").addEventListener("click", () => {
+        row.remove();
+        renameReceiptInputs();
+      });
+      tableBody.appendChild(row);
+      renameReceiptInputs();
+    };
+
+    addButton.addEventListener("click", addLine);
+    addLine();
+  });
+</script>
+{% endblock %}

--- a/templates/expenses/review_report.html
+++ b/templates/expenses/review_report.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}Review Expense Report{% endblock %}
+{% block content %}
+<h1 class="h3">Review Report #{{ report.id }}</h1>
+<p><strong>Employee:</strong> {{ report.employee.first_name or report.employee.email }}</p>
+<p><strong>Status:</strong> {{ report.status }}</p>
+
+<div class="table-responsive mb-3">
+  <table class="table table-bordered">
+    <thead><tr><th>Date</th><th>Type</th><th>GL</th><th>Vendor</th><th>Description</th><th>Amount</th><th>Receipt</th></tr></thead>
+    <tbody>
+      {% for line in report.lines %}
+      <tr>
+        <td>{{ line.date.strftime('%Y-%m-%d') }}</td>
+        <td>{{ line.expense_type }}</td>
+        <td>{{ line.gl_account }}</td>
+        <td>{{ line.vendor }}</td>
+        <td>{{ line.description }}</td>
+        <td>${{ '%.2f'|format(line.amount) }}</td>
+        <td>{% if line.receipt_url %}<a href="{{ line.receipt_url }}" target="_blank" rel="noopener">View</a>{% else %}<span class="text-muted">None</span>{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  <div class="mb-3">
+    <label class="form-label">Rejection Comment (required for reject)</label>
+    <textarea class="form-control" name="comment" rows="3"></textarea>
+  </div>
+  <div class="d-flex gap-2">
+    <button class="btn btn-success" name="action" value="approve">Approve</button>
+    <button class="btn btn-danger" name="action" value="reject">Reject</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/expenses/supervisor_dashboard.html
+++ b/templates/expenses/supervisor_dashboard.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Supervisor Dashboard{% endblock %}
+{% block content %}
+<h1 class="h3">Pending Review</h1>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead><tr><th>Report</th><th>Employee</th><th>Month</th><th>Submitted</th><th></th></tr></thead>
+    <tbody>
+      {% for report in reports %}
+      <tr>
+        <td>#{{ report.id }}</td>
+        <td>{{ report.employee.first_name or report.employee.email }}</td>
+        <td>{{ report.report_month.strftime('%Y-%m') }}</td>
+        <td>{{ report.created_at.strftime('%Y-%m-%d') }}</td>
+        <td><a class="btn btn-sm btn-primary" href="{{ url_for('expenses.review_report', report_id=report.id) }}">Review</a></td>
+      </tr>
+      {% else %}
+      <tr><td colspan="5" class="text-muted">No reports pending review.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% if current_user.role == 'super_admin' %}
+<form method="post" action="{{ url_for('expenses.dispatch_pending_uploads') }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  <button class="btn btn-success">Dispatch Pending Uploads (SFTP)</button>
+  <a class="btn btn-outline-secondary" href="{{ url_for('expenses.export_pending_upload_csv') }}">Download Pending Upload CSV</a>
+</form>
+{% endif %}
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_expense_workflow.py
+++ b/tests/test_expense_workflow.py
@@ -1,0 +1,11 @@
+from server_config import resolve_debug_flag, resolve_port
+
+
+def test_resolve_port_uses_default_for_invalid_value(monkeypatch):
+    monkeypatch.setenv("PORT", "abc")
+    assert resolve_port() == 5000
+
+
+def test_resolve_debug_flag_understands_truthy_values(monkeypatch):
+    monkeypatch.setenv("FLASK_DEBUG", "yes")
+    assert resolve_debug_flag() is True

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,0 +1,11 @@
+from server_config import resolve_secret_value
+
+
+def test_resolve_secret_value_prefers_plain_env(monkeypatch):
+    monkeypatch.setenv("NETSUITE_SFTP_PASSWORD", "local-secret")
+    monkeypatch.delenv("NETSUITE_SFTP_PASSWORD_SECRET", raising=False)
+
+    assert (
+        resolve_secret_value("NETSUITE_SFTP_PASSWORD", "NETSUITE_SFTP_PASSWORD_SECRET")
+        == "local-secret"
+    )


### PR DESCRIPTION
## Summary
- Added expense-domain schema support in `models.py`:
  - `User.supervisor_id` self-referential hierarchy
  - `ExpenseReport` (header) with lifecycle status enum (`Draft`, `Pending Review`, `Pending Upload`, `Completed`)
  - `ExpenseLine` (line items) with spreadsheet-aligned fields (`date`, `expense_type`, `gl_account`, `vendor`, `amount`) plus receipt URL
- Restricted registration in `auth.py` to internal employee domain accounts and kept new accounts pending admin approval (`employee_approved=False`).
- Added new expense workflow blueprint (`expenses.py`) and wired it into app startup:
  - Employee report creation with dynamic multi-line entry
  - Supervisor dashboard showing only `Pending Review` reports assigned to `supervisor_id == current_user.id`
  - Supervisor approval/rejection flow with mandatory rejection comment
  - Pending-upload CSV export and SFTP dispatch endpoint that marks sent reports as `Completed`
- Added `services/expense_workflow.py` for:
  - Loading GL accounts and expense types from `Dave Alexander Expense Report 12.12.2023.xlsx` (`GL Accounts` and `Data List` sheets)
  - Cloud Storage receipt upload helper
  - NetSuite upload CSV formatting
  - SFTP dispatch helper
- Added expense templates and JS line-row cloning behavior:
  - `templates/expenses/new_expense.html`
  - `templates/expenses/my_reports.html`
  - `templates/expenses/supervisor_dashboard.html`
  - `templates/expenses/review_report.html`
- Updated navigation links in `templates/base.html`.
- Added secret-manager-aware credential loading utility in `server_config.py` and referenced it from `config.py` for sensitive values.
- Updated `requirements.txt` for `google-cloud-storage` and `paramiko`.
- Updated `README.md` with explicit reference workbook guidance and reimbursement policy summary.
- Added baseline tests under `tests/` and `pytest.ini`.

## Testing
- `black models.py auth.py __init__.py database.py config.py server_config.py expenses.py services/expense_workflow.py tests/test_expense_workflow.py tests/test_server_config.py`
- `pytest`

## Notes / Follow-ups
- `pytest` currently fails during collection due existing repository package import layout conflicts (`app` module vs package-style imports and root `__init__.py` collection behavior). I left the failure visible rather than masking it so the import layout can be fixed explicitly in a follow-up.
- No database migration revision was generated in this PR; schema changes are present in SQLAlchemy models and should be followed by an Alembic migration in environments where migrations are required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984b54e1974833388632b5d07b250bd)