### PR TITLE
Enforce dynamic GL account validation in expense form

### DIFF
--- a/templates/expenses/new_expense.html
+++ b/templates/expenses/new_expense.html
@@ -46,12 +46,6 @@
   </div>
 </form>
 
-<datalist id="gl-account-options">
-  {% for option in gl_accounts %}
-  <option value="{{ option.account }}">{{ option.label }}</option>
-  {% endfor %}
-</datalist>
-
 <template id="expense-row-template">
   <tr>
     <td><input type="date" class="form-control" name="line_date" required /></td>
@@ -63,7 +57,11 @@
         {% endfor %}
       </select>
     </td>
-    <td><input class="form-control" name="gl_account" list="gl-account-options" placeholder="52070" required /></td>
+    <td>
+      <select class="form-select" name="gl_account" required>
+        <option value="">Loading GL accounts…</option>
+      </select>
+    </td>
     <td><input class="form-control" name="description" maxlength="255" /></td>
     <td><input class="form-control" name="vendor" maxlength="255" required /></td>
     <td><input type="number" class="form-control" name="amount" min="0" step="0.01" required /></td>
@@ -77,6 +75,8 @@
     const tableBody = document.getElementById("expense-lines");
     const template = document.getElementById("expense-row-template");
     const addButton = document.getElementById("add-line-btn");
+    const glAccountsEndpoint = "{{ url_for('expenses.gl_accounts_options') }}";
+    let glAccountOptions = [];
 
     const renameReceiptInputs = () => {
       tableBody.querySelectorAll("tr").forEach((row, index) => {
@@ -87,9 +87,78 @@
       });
     };
 
+    const setAccountCellMessage = (selectElement, message) => {
+      selectElement.innerHTML = "";
+      const option = document.createElement("option");
+      option.value = "";
+      option.textContent = message;
+      selectElement.appendChild(option);
+      selectElement.disabled = true;
+    };
+
+    const populateAccountSelect = (selectElement) => {
+      selectElement.innerHTML = "";
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select account";
+      selectElement.appendChild(placeholder);
+
+      glAccountOptions.forEach((optionData) => {
+        const option = document.createElement("option");
+        option.value = optionData.account;
+        option.textContent = optionData.label;
+        selectElement.appendChild(option);
+      });
+
+      selectElement.disabled = glAccountOptions.length === 0;
+      if (glAccountOptions.length === 0) {
+        placeholder.textContent = "No GL accounts available";
+      }
+    };
+
+    const applyAccountsToExistingRows = () => {
+      tableBody.querySelectorAll('select[name="gl_account"]').forEach((selectElement) => {
+        populateAccountSelect(selectElement);
+      });
+    };
+
+    const fetchGlAccounts = async () => {
+      try {
+        const response = await fetch(glAccountsEndpoint, {
+          method: "GET",
+          headers: { "Accept": "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to load GL accounts (${response.status})`);
+        }
+
+        const payload = await response.json();
+        if (!payload || !Array.isArray(payload.accounts)) {
+          throw new Error("GL accounts response was invalid.");
+        }
+
+        glAccountOptions = payload.accounts.filter((optionData) => {
+          return optionData && optionData.account && optionData.label;
+        });
+        applyAccountsToExistingRows();
+      } catch (error) {
+        console.error(error);
+        tableBody.querySelectorAll('select[name="gl_account"]').forEach((selectElement) => {
+          setAccountCellMessage(selectElement, "Unable to load GL accounts");
+        });
+      }
+    };
+
     const addLine = () => {
       const fragment = template.content.cloneNode(true);
       const row = fragment.querySelector("tr");
+      const accountSelect = row.querySelector('select[name="gl_account"]');
+      if (glAccountOptions.length > 0) {
+        populateAccountSelect(accountSelect);
+      } else {
+        setAccountCellMessage(accountSelect, "Loading GL accounts…");
+      }
+
       row.querySelector(".remove-line-btn").addEventListener("click", () => {
         row.remove();
         renameReceiptInputs();
@@ -100,6 +169,7 @@
 
     addButton.addEventListener("click", addLine);
     addLine();
+    fetchGlAccounts();
   });
 </script>
 {% endblock %}

--- a/tests/test_expenses_form_validation.py
+++ b/tests/test_expenses_form_validation.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_expense_form_uses_dynamic_gl_account_select() -> None:
+    """Ensure the expense form uses a dynamic select fed by the GL endpoint."""
+
+    template_path = Path("templates/expenses/new_expense.html")
+    content = template_path.read_text(encoding="utf-8")
+
+    assert (
+        "const glAccountsEndpoint = \"{{ url_for('expenses.gl_accounts_options') }}\";"
+        in content
+    )
+    assert '<select class="form-select" name="gl_account" required>' in content
+    assert '<datalist id="gl-account-options">' not in content
+
+
+def test_expenses_module_exposes_gl_accounts_endpoint() -> None:
+    """Ensure expenses routes include the JSON endpoint used by frontend validation."""
+
+    module_path = Path("expenses.py")
+    content = module_path.read_text(encoding="utf-8")
+
+    assert '@expenses_bp.get("/gl-accounts")' in content
+    assert "select a GL account from the approved list" in content


### PR DESCRIPTION
### Motivation
- Prevent users from submitting invalid manual GL account codes by making the frontend consume the canonical GL Accounts source and enforcing the same source server-side.
- Move GL account choices to a dynamic JSON endpoint so the UI always reflects the current workbook-backed source of truth.

### Description
- Added `GET /expenses/gl-accounts` (`gl_accounts_options`) which returns JSON account objects sourced from `app.services.expense_workflow.load_gl_accounts` for frontend consumption.
- Added helper `_gl_account_code_set()` and server-side validation in `new_expense` to reject any submitted `gl_account` not present in the current workbook-derived set.
- Replaced the freeform datalist input with a controlled `<select name="gl_account">` in `templates/expenses/new_expense.html` and added client-side JS that fetches `{{ url_for('expenses.gl_accounts_options') }}` and populates per-line selects with loading/error fallbacks.
- Added `tests/test_expenses_form_validation.py` which asserts the template and module include the new frontend wiring and backend validation messaging.

### Testing
- Formatted with `black` via `black expenses.py tests/test_expenses_form_validation.py` and the formatting step succeeded.
- Ran the test suite with `pytest`, but test collection failed due to existing repository import-path/top-level package relative-import issues (errors during import of top-level `__init__.py`/`app.py`) which are unrelated to the expense form changes; as a result the test run did not complete successfully.
- Created `tests/test_expenses_form_validation.py` and confirmed its assertions against the updated files locally, but full `pytest` execution is blocked by the unrelated import-path problem.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984b889f71c83338df4039998855d6a)