### PR TITLE
Add Dockerfile and .dockerignore; point Cloud Build to repo Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml
+htmlcov/
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Local tooling and git metadata
+.git/
+.gitignore
+.idea/
+.vscode/
+
+# OS/editor artifacts
+.DS_Store
+Thumbs.db
+
+# Test and docs artifacts not required at runtime
+tests/
+*.log
+*.sqlite
+*.db
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# Local and large non-runtime artifacts
+*.xlsx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "wsgi:app"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,8 @@ steps:
   - name: gcr.io/cloud-builders/docker
     args:
       - build
+      - -f
+      - Dockerfile
       - -t
       - ${_IMAGE_URI}
       - .


### PR DESCRIPTION
### Motivation
- Provide a proper repository-driven Docker image build for the Flask app so Cloud Build produces and pushes a real image for deployment instead of falling back to placeholder behavior.

### Description
- Add a root `Dockerfile` based on `python:3.11-slim` that installs dependencies from `requirements.txt`, copies the app, exposes port `8080`, and runs `gunicorn --bind 0.0.0.0:8080 wsgi:app`, add a root `.dockerignore` to exclude venvs, caches, test artifacts, and large non-runtime files, and update `cloudbuild.yaml` to pass `-f Dockerfile` while keeping the build context as `.`.

### Testing
- Ran `pytest` (the test run failed during import/collection with relative-import errors that are unrelated to these Docker/Cloud Build changes) and attempted `docker build -f Dockerfile -t expenses-test:local .` but the `docker` CLI is not available in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984c0809f008333a95353463c425427)