### PR TITLE
Harden Cloud Build Cloud Run deployment with explicit project and digest pinning

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,24 +7,71 @@ steps:
       - -t
       - ${_IMAGE_URI}
       - .
+
   - name: gcr.io/cloud-builders/docker
     args:
       - push
       - ${_IMAGE_URI}
+
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    id: resolve-image-digest
+    entrypoint: bash
     args:
-      - run
-      - deploy
-      - ${_SERVICE}
-      - --image=${_IMAGE_URI}
-      - --region=${_REGION}
-      - --platform=managed
-      - --allow-unauthenticated
-      - --quiet
+      - -c
+      - |
+        set -euo pipefail
+        DIGEST="$(gcloud artifacts docker images describe "${_IMAGE_URI}" --project="${_PROJECT_ID}" --format='get(image_summary.digest)')"
+        if [[ -z "${DIGEST}" ]]; then
+          echo "Failed to resolve digest for ${_IMAGE_URI}" >&2
+          exit 1
+        fi
+
+        IMAGE_WITH_DIGEST="${_IMAGE_REPO}@${DIGEST}"
+        printf '%s' "${IMAGE_WITH_DIGEST}" > /workspace/image_to_deploy.txt
+        echo "Resolved deploy image: ${IMAGE_WITH_DIGEST}"
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: deploy-cloud-run
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        IMAGE_TO_DEPLOY="$(cat /workspace/image_to_deploy.txt)"
+        gcloud run deploy ${_SERVICE} --image=${IMAGE_TO_DEPLOY} --region=${_REGION} --project=${_PROJECT_ID} --platform=managed --allow-unauthenticated --quiet
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: verify-deployed-image
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        DEPLOYED_IMAGE="$(gcloud run services describe "${_SERVICE}" --region="${_REGION}" --project="${_PROJECT_ID}" --format='value(spec.template.spec.containers[0].image)')"
+
+        if [[ -z "${DEPLOYED_IMAGE}" ]]; then
+          echo "Unable to fetch deployed image for service ${_SERVICE}." >&2
+          exit 1
+        fi
+
+        if [[ "${DEPLOYED_IMAGE}" == gcr.io/cloudrun/placeholder* ]]; then
+          echo "Deployment verification failed: service still points to placeholder image (${DEPLOYED_IMAGE})." >&2
+          exit 1
+        fi
+
+        if [[ "${DEPLOYED_IMAGE}" != ${_IMAGE_REPO}@sha256:* ]]; then
+          echo "Deployment verification failed: unexpected deployed image (${DEPLOYED_IMAGE})." >&2
+          exit 1
+        fi
+
+        echo "Deployment verification passed: ${DEPLOYED_IMAGE}"
+
 substitutions:
-  _IMAGE_URI: us-central1-docker.pkg.dev/PROJECT/REPO/quote-tool:latest
-  _SERVICE: quote-tool
+  _PROJECT_ID: quote-tool-483716
+  _SERVICE: expenses
   _REGION: us-central1
+  _IMAGE_REPO: us-central1-docker.pkg.dev/quote-tool-483716/cloud-run-source-deploy/expenses/expenses
+  _IMAGE_URI: us-central1-docker.pkg.dev/quote-tool-483716/cloud-run-source-deploy/expenses/expenses:${SHORT_SHA}
+
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
### Motivation
- Ensure Cloud Build deploys a deterministic, pushed Artifact Registry image to Cloud Run instead of a source or placeholder image. 
- Prevent accidental cross-project deploys by making the project explicit in deploy/verify steps.
- Prefer digest-pinned images for reproducible Cloud Run revisions.

### Description
- Updated `cloudbuild.yaml` substitutions to production-aligned values including `_SERVICE: expenses`, `_PROJECT_ID`, `_IMAGE_REPO`, and an immutable `_IMAGE_URI` using `${SHORT_SHA}`.
- Added a digest-resolution step after the image `push` that queries Artifact Registry and writes an `image@sha256:...` target to `/workspace/image_to_deploy.txt`.
- Kept the image-based deploy command and replaced the fallback/source deploy path with `gcloud run deploy ${_SERVICE} --image=${IMAGE_TO_DEPLOY} --region=${_REGION} --project=${_PROJECT_ID} --platform=managed --allow-unauthenticated --quiet` to satisfy deterministic deployment.
- Added a post-deploy verification step that fails if the service image is `gcr.io/cloudrun/placeholder` or does not match the expected Artifact Registry repo with a SHA digest.

### Testing
- Ran the test suite with `pytest`; test collection failed with `ImportError: attempted relative import with no known parent package`, which is unrelated to the `cloudbuild.yaml` changes and indicates existing package/import issues in the repo.
- No CI deployment was executed as part of these changes; the `cloudbuild.yaml` changes are structured to surface failures early (digest resolution and verification steps will fail the build if expectations are not met).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984c11f501c8333b0c38615bca5f993)