### PR TITLE
Harden Cloud Run environment and secret wiring for production deploys

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,7 +38,16 @@ steps:
       - |
         set -euo pipefail
         IMAGE_TO_DEPLOY="$(cat /workspace/image_to_deploy.txt)"
-        gcloud run deploy ${_SERVICE} --image=${IMAGE_TO_DEPLOY} --region=${_REGION} --project=${_PROJECT_ID} --platform=managed --allow-unauthenticated --quiet
+        gcloud run deploy ${_SERVICE} \
+          --image=${IMAGE_TO_DEPLOY} \
+          --region=${_REGION} \
+          --project=${_PROJECT_ID} \
+          --platform=managed \
+          --allow-unauthenticated \
+          --add-cloudsql-instances=${_CLOUD_SQL_CONNECTION_NAME} \
+          --set-env-vars=ENVIRONMENT=production,FLASK_DEBUG=false,STARTUP_DB_CHECKS=true,HEALTHCHECK_REQUIRE_DB=true \
+          --set-secrets=SECRET_KEY=${_SECRET_KEY_SECRET},OIDC_CLIENT_ID=${_OIDC_CLIENT_ID_SECRET},OIDC_CLIENT_SECRET=${_OIDC_CLIENT_SECRET},OIDC_ISSUER=${_OIDC_ISSUER_SECRET},OIDC_AUDIENCE=${_OIDC_AUDIENCE_SECRET},NETSUITE_SFTP_PASSWORD=${_NETSUITE_SFTP_PASSWORD_SECRET},NETSUITE_SFTP_PRIVATE_KEY=${_NETSUITE_SFTP_PRIVATE_KEY_SECRET},NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE=${_NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE_SECRET},DATABASE_URL=${_DATABASE_URL_SECRET} \
+          --quiet
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: verify-deployed-image
@@ -72,6 +81,16 @@ substitutions:
   _REGION: us-central1
   _IMAGE_REPO: us-central1-docker.pkg.dev/quote-tool-483716/cloud-run-source-deploy/expenses/expenses
   _IMAGE_URI: us-central1-docker.pkg.dev/quote-tool-483716/cloud-run-source-deploy/expenses/expenses:${SHORT_SHA}
+  _CLOUD_SQL_CONNECTION_NAME: quote-tool-483716:us-central1:quotetool-postgres-instance
+  _DATABASE_URL_SECRET: DATABASE_URL:latest
+  _SECRET_KEY_SECRET: SECRET_KEY:latest
+  _OIDC_CLIENT_ID_SECRET: OIDC_CLIENT_ID:latest
+  _OIDC_CLIENT_SECRET: OIDC_CLIENT_SECRET:latest
+  _OIDC_ISSUER_SECRET: OIDC_ISSUER:latest
+  _OIDC_AUDIENCE_SECRET: OIDC_AUDIENCE:latest
+  _NETSUITE_SFTP_PASSWORD_SECRET: NETSUITE_SFTP_PASSWORD:latest
+  _NETSUITE_SFTP_PRIVATE_KEY_SECRET: NETSUITE_SFTP_PRIVATE_KEY:latest
+  _NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE_SECRET: NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE:latest
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/config.py
+++ b/config.py
@@ -694,14 +694,23 @@ class Config:
     )
     API_AUTH_TOKEN = os.getenv("API_AUTH_TOKEN")
     API_QUOTE_RATE_LIMIT = os.getenv("API_QUOTE_RATE_LIMIT", "30 per minute")
-    OIDC_ISSUER = os.getenv("OIDC_ISSUER")
-    OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID")
+    OIDC_ISSUER = resolve_secret_value("OIDC_ISSUER", "OIDC_ISSUER_SECRET")
+    OIDC_CLIENT_ID = resolve_secret_value("OIDC_CLIENT_ID", "OIDC_CLIENT_ID_SECRET")
     OIDC_CLIENT_SECRET = resolve_secret_value(
         "OIDC_CLIENT_SECRET", "OIDC_CLIENT_SECRET_NAME"
     )
     OIDC_REDIRECT_URI = os.getenv("OIDC_REDIRECT_URI")
     OIDC_SCOPES = _resolve_oidc_scopes()
-    OIDC_AUDIENCE = _resolve_oidc_audience()
+    OIDC_AUDIENCE = (
+        tuple(
+            item.strip()
+            for item in resolve_secret_value(
+                "OIDC_AUDIENCE", "OIDC_AUDIENCE_SECRET"
+            ).split(",")
+            if item.strip()
+        )
+        or _resolve_oidc_audience()
+    )
     OIDC_ALLOWED_DOMAIN = _resolve_oidc_allowed_domain()
     OIDC_END_SESSION_ENDPOINT = os.getenv("OIDC_END_SESSION_ENDPOINT")
     EXPENSE_RECEIPT_BUCKET = os.getenv("EXPENSE_RECEIPT_BUCKET", "").strip()
@@ -710,6 +719,13 @@ class Config:
     NETSUITE_SFTP_USERNAME = os.getenv("NETSUITE_SFTP_USERNAME", "").strip()
     NETSUITE_SFTP_PASSWORD = resolve_secret_value(
         "NETSUITE_SFTP_PASSWORD", "NETSUITE_SFTP_PASSWORD_SECRET"
+    )
+    NETSUITE_SFTP_PRIVATE_KEY = resolve_secret_value(
+        "NETSUITE_SFTP_PRIVATE_KEY", "NETSUITE_SFTP_PRIVATE_KEY_SECRET"
+    )
+    NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE = resolve_secret_value(
+        "NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE",
+        "NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE_SECRET",
     )
     NETSUITE_SFTP_DIRECTORY = os.getenv("NETSUITE_SFTP_DIRECTORY", "/").strip()
 

--- a/tests/test_config_secret_env_mapping.py
+++ b/tests/test_config_secret_env_mapping.py
@@ -1,0 +1,70 @@
+"""Tests for secret-backed environment variable mappings in ``config.Config``."""
+
+import importlib
+
+import config as config_module
+
+
+def _reload_config_module():
+    """Reload and return ``config`` after monkeypatched environment updates.
+
+    Inputs:
+        None. Reads process environment configured by ``monkeypatch`` in tests.
+
+    Outputs:
+        The reloaded ``config`` module object so callers can inspect
+        ``config.Config`` values.
+
+    External dependencies:
+        Calls :func:`importlib.reload` to refresh module-level configuration.
+    """
+
+    return importlib.reload(config_module)
+
+
+def test_oidc_values_can_be_read_from_direct_secret_env(monkeypatch):
+    """Ensure OIDC values map from env vars used for Secret Manager injection.
+
+    Inputs:
+        monkeypatch: pytest fixture used to set environment variables.
+
+    Outputs:
+        None. Asserts expected values on ``Config`` attributes.
+
+    External dependencies:
+        Reloads ``config`` via helper ``_reload_config_module``.
+    """
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg2://u:p@db:5432/app")
+    monkeypatch.setenv("OIDC_CLIENT_ID", "client-id-from-secret")
+    monkeypatch.setenv("OIDC_ISSUER", "https://issuer.example.com")
+    monkeypatch.setenv("OIDC_AUDIENCE", "audience-a,audience-b")
+
+    config = _reload_config_module()
+
+    assert config.Config.OIDC_CLIENT_ID == "client-id-from-secret"
+    assert config.Config.OIDC_ISSUER == "https://issuer.example.com"
+    assert config.Config.OIDC_AUDIENCE == ("audience-a", "audience-b")
+
+
+def test_netsuite_key_material_can_be_read_from_secret_env(monkeypatch):
+    """Ensure NetSuite key credentials use the expected environment variables.
+
+    Inputs:
+        monkeypatch: pytest fixture used to set environment variables.
+
+    Outputs:
+        None. Asserts key and passphrase values are exposed on ``Config``.
+
+    External dependencies:
+        Reloads ``config`` via helper ``_reload_config_module``.
+    """
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg2://u:p@db:5432/app")
+    monkeypatch.setenv("NETSUITE_SFTP_PRIVATE_KEY", "private-key-bytes")
+    monkeypatch.setenv("NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE", "key-passphrase")
+
+    config = _reload_config_module()
+
+    assert config.Config.NETSUITE_SFTP_PRIVATE_KEY == "private-key-bytes"
+    assert config.Config.NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE == "key-passphrase"


### PR DESCRIPTION
### Motivation
- Ensure Cloud Run deployments use explicit non-secret production flags and fail fast when critical runtime configuration is missing. 
- Move sensitive credentials into Secret Manager and map them cleanly into the app configuration so the runtime names used by Cloud Run match `config.Config` identifiers. 
- Provide a clear deployment runbook and CI defaults that attach Cloud SQL and inject secrets securely for Cloud Run. 

### Description
- Use `resolve_secret_value` in `config.py` to load OIDC values from secret-backed env vars and add `NETSUITE_SFTP_PRIVATE_KEY` and `NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE` mappings so NetSuite key material is read from Secret Manager. 
- Update `cloudbuild.yaml` deploy step to attach Cloud SQL with `--add-cloudsql-instances`, set non-secret production flags (`ENVIRONMENT=production`, `FLASK_DEBUG=false`, `STARTUP_DB_CHECKS=true`, `HEALTHCHECK_REQUIRE_DB=true`), and include Secret Manager-backed env var bindings (for `DATABASE_URL`, `SECRET_KEY`, OIDC secrets, and NetSuite secrets). 
- Revise `DEPLOYMENT.md` to document the exact env var and secret names used by Cloud Run, prefer `DATABASE_URL` as the Cloud Run strategy, and add a pre-release startup validation checklist to verify flags, Cloud SQL connection name, and secret bindings. 
- Add tests in `tests/test_config_secret_env_mapping.py` to assert secret-backed env var mappings for OIDC and NetSuite key material, and run `black` on modified files. 

### Testing
- Ran `black` on `config.py` and the new test file which reformatted `config.py` successfully. 
- Added `tests/test_config_secret_env_mapping.py` covering `OIDC_CLIENT_ID`/`OIDC_ISSUER`/`OIDC_AUDIENCE` and NetSuite private key/passphrase mappings. 
- Executed `pytest` from the repository root; collection failed due to import-path startup errors in the test environment (`ImportError: attempted relative import with no known parent package`) unrelated to the new config logic. 
- No new Python dependencies or database migrations were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984c1c7bcfc83338a2b6bbf29b8f626)