### PR TITLE
Rewrite core docs to focus on employee expense reporting

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,464 +1,93 @@
-# Deployment Guide
+# Deployment Guide (Employee Expense Reporting App)
 
-This document describes how to promote the Quote Tool application into a
-production environment on Cloud Run backed by Cloud SQL. It expands on the
-quick-start notes in `README.md` and is intended for operations staff who need
-precise, repeatable steps to stand up the service. For local development
-workflows (including Docker Compose), see
-[docs/local_dev.md](docs/local_dev.md). For a cross-reference of the full
-documentation set, consult [docs/README.md](docs/README.md).
+This document explains how to deploy the employee expense reporting app safely
+and consistently.
 
-## 1. Prerequisites
+## 1. Runtime requirements
 
-1. **Cloud project access** – A Google Cloud project with billing enabled and
-   permissions to manage Cloud Run, Cloud SQL, Artifact Registry, and IAM.
-2. **Container build tooling** – Use Cloud Build or a local Docker Engine 24+
-   install to build and push container images.
-3. **Domain name and DNS** – Decide on the hostname you will publish and
-   create the matching DNS record in your managed DNS provider. Cloud Run
-   domain mappings and HTTPS load balancers both require the hostname to point
-   at Google-managed endpoints before TLS can be provisioned.
-4. **Ingress and TLS strategy** – Choose whether Cloud Run will be public
-   (**Allow all traffic**) or limited to VPC/private traffic (**Internal** or
-   **Internal and Cloud Load Balancing**). Cloud Run and Google-managed HTTPS
-   load balancers automatically issue and renew TLS certificates for custom
-   domains.
-5. **External services** – Provision the dependencies used by the Quote Tool:
-   - **Database** – Cloud SQL for PostgreSQL 13+ is required. The application
-     depends on PostgreSQL in all environments, including local development.
-   - **Google Maps API access** – Enable the Distance Matrix API and obtain an
-     API key.
-   - **Redis (optional)** – Use a managed Redis provider (for example, Cloud
-     Memorystore) when `CACHE_TYPE` points at Redis.
-   - **SMTP relay (optional)** – Needed for password reset emails. Configure the
-     `MAIL_*` settings if you enable this feature.
+- Python 3.8+
+- A production database reachable by the app
+- Environment variable management for secrets/config
+- Process manager or container runtime (Gunicorn/Hypercorn, Docker, or Cloud Run)
 
-## 2. Fetch the application
+## 2. Required configuration
 
-Clone the repository (or download the release archive) onto the deployment
-host:
+Set these values through environment variables or your secret manager:
+
+- `SECRET_KEY`: required for secure session signing
+- `DATABASE_URL` (or equivalent SQLAlchemy URI): required database connection
+- Mail/settings values used by your environment (if enabled)
+- Any app-specific authentication or integration settings in your deployment profile
+
+## 3. Build and install
+
+### Option A: standard host/VM deploy
 
 ```bash
-sudo mkdir -p /opt/quote_tool
-sudo chown "$USER" /opt/quote_tool
-cd /opt/quote_tool
-git clone https://example.com/your-fork.git .
+pip install -r requirements.txt
 ```
 
-If you maintain a private fork, update the URL accordingly. Verify the working
-tree is clean before continuing:
+Run migrations/schema setup required by your environment before first traffic.
+
+### Option B: Docker image
 
 ```bash
-git status -sb
+docker build -t expense-reporting-app:latest .
 ```
 
-## 3. Configure environment variables
-
-Configure environment variables in Cloud Run (or a CI/CD system that deploys to
-Cloud Run). Store secrets in Secret Manager and reference them in the service
-configuration instead of committing a `.env` file. Generate a deployment secret
-with `python -c 'import secrets; print(secrets.token_urlsafe(32))'` and paste
-the output into `SECRET_KEY` so the Flask app can reuse it across restarts.
-Production deployments must define `SECRET_KEY` (otherwise the app starts in
-maintenance mode and reports a configuration error when `ENVIRONMENT` or
-`FLASK_ENV` is set to `production`). Provide either a Cloud SQL connection name
-or a full PostgreSQL DSN (`DATABASE_URL`) so the container can connect to Cloud
-SQL. The `scripts/deploy.sh` workflow now creates or updates Secret Manager
-entries named `${SERVICE_NAME}-db-password`, `${SERVICE_NAME}-secret-key`, and
-`${SERVICE_NAME}-maps-key` before it deploys the Cloud Run service, so ensure
-the operator has the required permissions to manage secrets.
-
-```dotenv
-# Core application settings
-# Generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'
-SECRET_KEY=replace-with-long-random-string
-GOOGLE_MAPS_API_KEY=your-google-key
-FLASK_DEBUG=false
-TZ=UTC
-POSTGRES_USER=quote_tool
-POSTGRES_PASSWORD=strong_password
-POSTGRES_DB=quote_tool
-POSTGRES_HOST=cloudsql-hostname
-# DATABASE_URL=postgresql+psycopg2://override_user:override_password@override-host:5432/override_db
-
-# Optional tuning (uncomment as needed)
-# DB_POOL_SIZE=10
-# CACHE_TYPE=redis
-# CACHE_REDIS_URL=redis://redis-host:6379/0
-# RATELIMIT_STORAGE_URI=redis://redis-host:6379/1
-# MAIL_DEFAULT_SENDER=quote@freightservices.net
-# MAIL_SERVER=smtp.gmail.com
-# MAIL_PORT=587
-# MAIL_USE_TLS=true
-# MAIL_USERNAME=quote@freightservices.net
-# MAIL_PASSWORD=app-password
-# MAIL_ALLOWED_SENDER_DOMAIN=freightservices.net
-# MAIL_PRIVILEGED_DOMAIN=freightservices.net
-# MAIL_RATE_LIMIT_PER_RECIPIENT_PER_DAY=25
-# MAIL_RATE_LIMIT_PER_USER_PER_HOUR=10
-# MAIL_RATE_LIMIT_PER_USER_PER_DAY=50
-# MAIL_RATE_LIMIT_PER_FEATURE_PER_HOUR=200
-# RATE_DATA_DIR=/app/rates  # Custom directory for CSV imports
-# ADMIN_EMAIL=admin@example.com
-# ADMIN_PASSWORD=initial-password
-```
-
-When configuring Gmail SMTP, use `smtp.gmail.com` with port 587 and
-`MAIL_USE_TLS=true`. Gmail requires either OAuth 2.0 or an app password for
-accounts with two-step verification enabled; basic username/password sign-in
-without app passwords is no longer supported for most accounts. If you prefer
-SSL on port 465, set `MAIL_USE_SSL=true` and disable TLS.
-
-### Seed secrets in Secret Manager
-
-Store sensitive values in Secret Manager and reference them from Cloud Run
-instead of committing them to `.env` files. The script below wraps the standard
-`gcloud secrets create` and `gcloud secrets versions add` commands and creates
-secrets for the database password, SMTP password, and Google Maps API key:
+Run with environment variables:
 
 ```bash
-export PROJECT_ID="your-project-id"
-export POSTGRES_PASSWORD="replace-with-db-password"
-export MAIL_PASSWORD="replace-with-mail-password"
-export GOOGLE_MAPS_API_KEY="replace-with-maps-key"
-./scripts/gcp/seed_secrets.sh
+docker run --rm -p 8080:8080 --env-file .env expense-reporting-app:latest
 ```
 
-If you prefer manual commands, the equivalent `gcloud` calls are:
+## 4. Start command
+
+Use a production WSGI/ASGI runner instead of the development server.
+Example Gunicorn-style startup:
 
 ```bash
-gcloud secrets create POSTGRES_PASSWORD --project=PROJECT --replication-policy=automatic
-printf "%s" "replace-with-db-password" | \\
-  gcloud secrets versions add POSTGRES_PASSWORD --project=PROJECT --data-file=-
-
-gcloud secrets create MAIL_PASSWORD --project=PROJECT --replication-policy=automatic
-printf "%s" "replace-with-mail-password" | \\
-  gcloud secrets versions add MAIL_PASSWORD --project=PROJECT --data-file=-
-
-gcloud secrets create GOOGLE_MAPS_API_KEY --project=PROJECT --replication-policy=automatic
-printf "%s" "replace-with-maps-key" | \\
-  gcloud secrets versions add GOOGLE_MAPS_API_KEY --project=PROJECT --data-file=-
+./scripts/start_gunicorn.sh
 ```
 
-### Bind secrets to Cloud Run
+or an equivalent command that invokes the Flask app factory/module used in your
+infrastructure.
 
-Bind Secret Manager values at deploy time with `--set-secrets`. Map the secret
-name to the environment variable expected by the app (for example, the
-`POSTGRES_PASSWORD` secret is injected as `POSTGRES_PASSWORD` in the container):
+## 5. Pre-release checklist
 
-```bash
-gcloud run deploy quote-tool \
-  --image=LOCATION-docker.pkg.dev/PROJECT/REPO/quote-tool:TAG \
-  --region=REGION \
-  --platform=managed \
-  --allow-unauthenticated \
-  --add-cloudsql-instances=PROJECT:REGION:INSTANCE \
-  --set-env-vars=ENVIRONMENT=production,FLASK_DEBUG=false,STARTUP_DB_CHECKS=true,HEALTHCHECK_REQUIRE_DB=true,CLOUD_SQL_CONNECTION_NAME=PROJECT:REGION:INSTANCE \
-  --set-secrets=DATABASE_URL=projects/PROJECT/secrets/DATABASE_URL:latest,\
-SECRET_KEY=projects/PROJECT/secrets/SECRET_KEY:latest,\
-OIDC_CLIENT_ID=projects/PROJECT/secrets/OIDC_CLIENT_ID:latest,\
-OIDC_CLIENT_SECRET=projects/PROJECT/secrets/OIDC_CLIENT_SECRET:latest,\
-OIDC_ISSUER=projects/PROJECT/secrets/OIDC_ISSUER:latest,\
-OIDC_AUDIENCE=projects/PROJECT/secrets/OIDC_AUDIENCE:latest,\
-NETSUITE_SFTP_PASSWORD=projects/PROJECT/secrets/NETSUITE_SFTP_PASSWORD:latest,\
-NETSUITE_SFTP_PRIVATE_KEY=projects/PROJECT/secrets/NETSUITE_SFTP_PRIVATE_KEY:latest,\
-NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE=projects/PROJECT/secrets/NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE:latest,\
-MAIL_PASSWORD=projects/PROJECT/secrets/MAIL_PASSWORD:latest,\
-GOOGLE_MAPS_API_KEY=projects/PROJECT/secrets/GOOGLE_MAPS_API_KEY:latest
-```
+Before promoting a release:
 
-When using `scripts/deploy.sh`, the deployment operator needs permissions to
-describe, create, and add new versions to secrets. Grant `roles/secretmanager.admin`
-or a least-privilege combination that includes `secretmanager.secrets.create`,
-`secretmanager.secrets.get`, and `secretmanager.versions.add` on the project or
-on the specific secrets.
+1. Run automated tests:
+   ```bash
+   pytest
+   ```
+2. Confirm login and password reset pages load
+3. Confirm employee expense creation/submission works end-to-end
+4. Confirm supervisor review actions (approve/reject) work
+5. Confirm admin dashboard access/permissions are correct
 
-### Cloud Run runtime IAM permissions
+## 6. Post-deploy smoke tests
 
-Ensure the Cloud Run runtime service account has the minimum IAM permissions
-required to read secrets and reach dependencies:
+After deployment:
 
-- `roles/secretmanager.secretAccessor` on the secrets above so Cloud Run can
-  inject values at startup.
-- `roles/cloudsql.client` if the service connects to Cloud SQL.
+- Verify health endpoint/home page loads
+- Submit a test expense report as an employee user
+- Review and approve/reject it as a supervisor user
+- Confirm report status updates are visible to the employee
 
-### Variable reference
-| Variable | Required | Purpose |
-| --- | --- | --- |
-| `ENVIRONMENT` | Yes | Set to `production` for Cloud Run releases so production-only safeguards are enforced. |
-| `FLASK_DEBUG` | Yes | Set to `false` in production to disable Flask's interactive debugger and reloader. |
-| `STARTUP_DB_CHECKS` | Recommended | Feature flag for startup validation checks. Keep `true` in production so missing tables/configuration fail fast during release. |
-| `HEALTHCHECK_REQUIRE_DB` | Recommended | Set to a truthy value so `/healthz` fails when database connectivity is broken. |
-| `CLOUD_SQL_CONNECTION_NAME` | Yes (Cloud Run + Cloud SQL) | Cloud SQL instance connection name (`project:region:instance`) and must match the Cloud Run `--add-cloudsql-instances` attachment. |
-| `DATABASE_URL` | Yes (Cloud Run) | Preferred database strategy. Inject from Secret Manager as a PostgreSQL DSN compatible with Cloud SQL host/socket settings. |
-| `SECRET_KEY` | Yes | Secures Flask sessions and CSRF tokens. Required in production when `ENVIRONMENT` or `FLASK_ENV` is `production`. |
-| `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER`, `OIDC_AUDIENCE` | Yes (when OIDC enabled) | OIDC identity-provider settings consumed by `config.py` and `services.oidc_client`; inject from Secret Manager in production. |
-| `NETSUITE_SFTP_PASSWORD`, `NETSUITE_SFTP_PRIVATE_KEY`, `NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE` | Yes (when NetSuite export enabled) | NetSuite SFTP authentication credentials and key material. Keep these in Secret Manager only. |
-| `GOOGLE_MAPS_API_KEY` | Yes | Authenticates calls to Google's Distance Matrix API. |
-| `TZ` | Yes | Time zone used for timestamp formatting and log rotation. |
-| `DB_POOL_SIZE` | No | Overrides the SQLAlchemy connection pool size when using PostgreSQL or MySQL. |
-| `CACHE_TYPE` / `CACHE_REDIS_URL` | No | Configure Flask-Caching. Leave unset to disable caching or point to your managed Redis instance. |
-| `RATELIMIT_STORAGE_URI` | No | Storage backend for Flask-Limiter counters. Defaults to `memory://` unless set to Redis. |
-| `MAIL_*` | No | Configure outbound email (SMTP host, credentials, TLS/SSL flags). Needed for password resets. |
-| `MAIL_ALLOWED_SENDER_DOMAIN` | No | Restricts `MAIL_DEFAULT_SENDER` to an approved sender domain (defaults to `freightservices.net`). |
-| `MAIL_PRIVILEGED_DOMAIN` | No | Controls which user email domains can access advanced mail features. |
-| `MAIL_RATE_LIMIT_PER_*` | No | Tune per-user, per-feature, and per-recipient rate limits for outbound email traffic. |
-| `RATE_DATA_DIR` | No | Directory containing the rate CSV files consumed by `init_db.py`. Defaults to the repository root. |
-| `ADMIN_EMAIL`, `ADMIN_PASSWORD` | No | When set, `init_db.py` bootstraps an administrator account with these credentials. |
-| `HEALTHCHECK_DB_TIMEOUT_SECONDS` | No | Timeout (in seconds) for the optional database probe performed by `/healthz`. Defaults to `2.0`. |
-Never commit the `.env` file to version control. Restrict filesystem
-permissions (`chmod 600 .env`) so only the deployment user can read it.
+## 7. Security and operations notes
 
-### Optional services and feature gating
+- Store secrets in a secret manager; do not commit secrets to git
+- Enforce HTTPS/TLS at the load balancer or ingress layer
+- Restrict admin and supervisor access using least-privilege accounts
+- Enable application logging/monitoring for workflow and auth failures
+- Back up the production database and define a tested restore process
 
-- **SMTP-dependent workflows** – Booking and volume-pricing email helpers, along with the quote summary emailer, require
-  outbound email credentials. Without `MAIL_*` values or runtime overrides, those buttons remain disabled for all users.
-- **Staff-only email features** – Even with SMTP enabled, only users whose email domain matches `MAIL_PRIVILEGED_DOMAIN` and who
-  are approved employees or super admins can access the booking and volume email forms. Customer accounts will see the controls
-  in a disabled state.
-- **Redis caching** – Disabled unless you explicitly set `CACHE_TYPE`. Confirm Redis credentials are reachable before enabling it.
+## 8. Rollback strategy
 
-## 4. Prepare Cloud SQL
+If deployment fails:
 
-Provision a Cloud SQL PostgreSQL instance and note the instance connection name
-(`project:region:instance`). Ensure the Cloud Run service account has
-permission to connect (`roles/cloudsql.client`) and that you have credentials
-ready for `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`.
-
-If you plan to connect over TCP (public or private IP), also capture the host
-and port so you can set `POSTGRES_HOST` and `POSTGRES_PORT` (or build a
-`DATABASE_URL`).
-
-## 5. Build and deploy the container
-
-Use Cloud Build or a local Docker build to publish your container image to
-Artifact Registry or another registry reachable by Cloud Run. Example using
-Cloud Build with the provided `cloudbuild.yaml` (which builds, pushes, and
-deploys to Cloud Run in one pipeline):
-
-```bash
-gcloud builds submit --config=cloudbuild.yaml \\
-  --substitutions=_IMAGE_URI=LOCATION-docker.pkg.dev/PROJECT/REPO/quote-tool:TAG,_SERVICE=quote-tool,_REGION=REGION \\
-  .
-```
-
-For an interactive workflow, `scripts/deploy.sh` prompts for the required
-Cloud Run environment values, infers the active project and existing service
-image when possible, and deploys with the Cloud SQL connection values needed
-by the application.
-
-### Cloud Run entrypoint
-
-The container image defaults to binding on `0.0.0.0:${PORT:-8080}` using
-Hypercorn's application factory callable (HTTP/2-capable when `h2` is installed).
-For Cloud Run, set the entrypoint to:
-
-```bash
-hypercorn --bind 0.0.0.0:${PORT:-8080} --workers 1 --access-logfile - "app.app:create_app()"
-```
-
-This entrypoint targets `app.app:create_app` and respects the platform-provided
-`PORT` value. Avoid passing `--factory` here; Gunicorn does not support that
-flag, and the `()` call syntax is the compatible way to invoke the factory
-function. Keep `flask_app.py` for local development only, as the production
-deployment uses the factory-based Hypercorn entrypoint above.
-
-### Cloud Build logging requirements (service accounts)
-
-If your Cloud Build trigger specifies a custom `build.service_account`, Cloud
-Build requires explicit log handling. Configure one of the supported logging
-strategies or the trigger fails with an `invalid argument` error. Choose the
-option that matches your security and retention needs:
-
-- **Log bucket** – Set `build.logs_bucket` to a user-owned Cloud Storage bucket
-  for build logs.
-- **Regional user-owned bucket** – Set
-  `build.options.default_logs_bucket_behavior` to
-  `REGIONAL_USER_OWNED_BUCKET`.
-- **Cloud Logging only** – Set `build.options.logging` to
-  `CLOUD_LOGGING_ONLY` (or `NONE` to disable logging).
-
-The repository now includes a ready-to-use `cloudbuild.yaml` that builds,
-pushes, and deploys the container image while enabling Cloud Logging only by
-default. Update the `_IMAGE_URI`, `_SERVICE`, and `_REGION` substitutions if you
-want to publish to a different registry, tag format, or Cloud Run destination.
-The pipeline defaults to `--allow-unauthenticated`; change that to
-`--no-allow-unauthenticated` if you want to require IAM authentication.
-
-Example `cloudbuild.yaml` fragment using Cloud Logging only:
-
-```yaml
-options:
-  logging: CLOUD_LOGGING_ONLY
-```
-
-Example `gcloud` command that sets the logging behavior on a trigger:
-
-```bash
-gcloud builds triggers update TRIGGER_NAME \
-  --region=REGION \
-  --build-config=cloudbuild.yaml \
-  --logging=CLOUD_LOGGING_ONLY
-```
-
-Review [Cloud Build logging options](https://cloud.google.com/build/docs/securing-builds/store-manage-build-logs)
-if you need to route logs to a dedicated bucket for compliance or retention.
-
-### Cloud Run probes
-
-Configure Cloud Run health checks to target the `/healthz` endpoint. The route
-returns `200 OK` with a plain-text `ok` body by default. If you want readiness
-and liveness probes to fail when the database is unavailable, set
-`HEALTHCHECK_REQUIRE_DB=true` and optionally tune
-`HEALTHCHECK_DB_TIMEOUT_SECONDS` (defaults to `2.0`) so the probe times out
-quickly.
-
-### Cloud Run database configuration
-
-Cloud Run deployments must use an external PostgreSQL database. The application
-will refuse to start in production if it cannot detect a valid PostgreSQL DSN.
-Choose one of the following Cloud SQL connection styles:
-
-- **Cloud SQL TCP (public/private IP)** – Configure a PostgreSQL `DATABASE_URL`
-  (recommended) or set `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`,
-  `POSTGRES_PASSWORD`, and `POSTGRES_DB`. When using Cloud SQL public IP, add
-  `POSTGRES_OPTIONS=sslmode=require` so the driver negotiates TLS.
-- **Cloud SQL Unix socket (Cloud Run)** – Set
-  `CLOUD_SQL_CONNECTION_NAME` alongside `POSTGRES_USER`,
-  `POSTGRES_PASSWORD`, and `POSTGRES_DB`. The application builds a socket-based
-  DSN that targets `/cloudsql/<connection-name>`, matching the mount injected
-  by the Cloud SQL Auth Proxy on Cloud Run. Optional `POSTGRES_OPTIONS` are
-  appended as query parameters.
-
-For the Quote Tool Cloud SQL instance, use the following values:
-
-```bash
-# Public IP (TCP)
-POSTGRES_HOST=104.198.53.60
-POSTGRES_PORT=5432
-POSTGRES_OPTIONS=sslmode=require
-```
-
-```bash
-# Cloud Run Unix socket
-CLOUD_SQL_CONNECTION_NAME=quote-tool-483716:us-central1:quotetool-postgres-instance
-```
-
-For Cloud SQL, ensure the instance is running **PostgreSQL**, not MySQL, because
-the application relies on PostgreSQL-specific drivers and migrations.
-
-### Apply database migrations
-
-Run Alembic migrations using a Cloud Run job or a temporary container that has
-network access to Cloud SQL. One approach is to create a Cloud Run job that runs
-the same image and executes `alembic upgrade head` with the same environment
-variables you set for the service.
-
-### Enable Redis caching and shared rate limiting (optional)
-
-Point `CACHE_TYPE`, `CACHE_REDIS_URL`, and `RATELIMIT_STORAGE_URI` at your
-managed Redis endpoint. When using Memorystore or another private Redis service,
-ensure the Cloud Run service connects over VPC and that the Redis instance
-allows traffic from the Cloud Run connector.
-
-### Seed rate tables and admin user
-
-The `init_db.py` helper imports base rate data and optionally creates an initial
-administrator. Run it once after migrations finish:
-
-Run the script in a Cloud Run job or a temporary container that can reach Cloud
-SQL. Use the same environment variables (`RATE_DATA_DIR`, `ADMIN_EMAIL`,
-`ADMIN_PASSWORD`) you configured for the service.
-
-If `RATE_DATA_DIR` is defined, the script reads CSV files from that directory.
-Otherwise it falls back to the CSVs checked into the repository root. Provide
-`ADMIN_EMAIL` and `ADMIN_PASSWORD` in `.env` (or export them temporarily) to
-bootstrap the first admin account.
-
-### Pre-release startup validation checklist
-
-Before promoting a release, run this checklist so deployments fail early when
-required env vars or secret bindings are missing:
-
-1. Confirm non-secret production flags on the Cloud Run service: `ENVIRONMENT=production`, `FLASK_DEBUG=false`, `STARTUP_DB_CHECKS=true`, and `HEALTHCHECK_REQUIRE_DB=true`.
-2. Confirm `CLOUD_SQL_CONNECTION_NAME` on Cloud Run exactly matches the target instance (`PROJECT:REGION:INSTANCE`) and is also attached through `--add-cloudsql-instances`.
-3. Confirm Secret Manager bindings exist for `DATABASE_URL`, `SECRET_KEY`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER`, `OIDC_AUDIENCE`, `NETSUITE_SFTP_PASSWORD`, `NETSUITE_SFTP_PRIVATE_KEY`, and `NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE`.
-4. Deploy and verify the new revision reaches `Ready=True`; if startup checks fail, inspect revision logs for missing env/secret errors and fix bindings before retrying.
-
-## 6. Maintenance
-
-### Backups
-
-Enable automated Cloud SQL backups and export snapshots before upgrades or
-schema changes. Store backups in a secured Cloud Storage bucket or your
-organization’s backup system so you can roll back if an upgrade introduces
-regressions.
-
-### Upgrades
-
-1. Back up the database using the command above (or your enterprise backup
-   solution).
-2. Build and publish a new container image (Cloud Build or local Docker).
-3. Deploy the new image to Cloud Run.
-4. Apply database migrations with the Cloud Run job described earlier.
-
-Review the official PostgreSQL release notes for breaking changes, especially
-when the underlying major version bumps. Major upgrades may require running
-`pg_upgrade` manually or restoring from dump files.
-
-## 7. Cloud Run ingress and TLS
-
-Use Cloud Run or a Google-managed HTTPS load balancer to terminate TLS and
-control inbound access:
-
-1. **Ingress settings** – Choose **Allow all traffic** for public access or
-   **Internal** / **Internal and Cloud Load Balancing** for private endpoints.
-2. **Custom domains** – Use Cloud Run domain mappings for direct custom domain
-   support, or place a HTTPS load balancer in front of the service for more
-   advanced routing, Cloud Armor policies, or IAP.
-3. **TLS certificates** – Google-managed certificates are provisioned and
-   renewed automatically once DNS records point at the Cloud Run or load
-   balancer endpoint.
-
-## 8. Health checks and smoke tests
-
-After the service is running, perform a quick validation:
-
-```bash
-curl -Ik https://quotes.example.com/
-```
-
-A successful response returns `HTTP/1.1 200 OK` (or a redirect to `/login`).
-Log in with the administrator credentials created earlier and verify you can
-request a quote.
-
-## 9. Routine maintenance
-
-- **Deploying updates** – Build and deploy a new container image, then run
-  migrations via a Cloud Run job.
-- **Backups** – Keep Cloud SQL backups and Cloud Run configuration exports (or
-  infrastructure-as-code) alongside any migration runbooks.
-- **Monitoring** – Stream Cloud Run logs to Cloud Logging or your preferred
-  SIEM. Probe the `/healthz` endpoint for liveness/readiness checks.
-
-## 10. Troubleshooting
-
-| Symptom | Resolution |
-| --- | --- |
-| `sqlalchemy.exc.OperationalError` on startup | Confirm the database host, port, and credentials in `DATABASE_URL`. Ensure outbound firewall rules permit traffic to the DB. |
-| Cloud Run returns `403` or `404` | Verify the service ingress setting, IAM policy, and domain mapping status. Ensure the DNS record points at the Cloud Run or load balancer target. |
-| Distance calculations fail | Validate `GOOGLE_MAPS_API_KEY` has the Distance Matrix API enabled and the server’s IP is authorized. |
-| Password reset emails do not send | Set the `MAIL_*` environment variables and confirm the SMTP relay allows connections from Cloud Run. |
-
-## 10. Security considerations
-
-- Rotate the `SECRET_KEY` and database credentials if you suspect compromise.
-  Changing `SECRET_KEY` will invalidate active sessions.
-- Restrict Cloud Run IAM access to trusted administrators. Use VPC firewall
-  rules and Cloud SQL authorized networks as needed.
-- Keep base images patched. Rebuild the image after applying dependency updates
-  in `requirements.txt`. Use `requirements-dev.txt` only for local development
-  workflows and CI tooling.
-
-Following this runbook yields a reproducible deployment of Quote Tool with HTTPS
-termination, seeded data, and a hardened configuration ready for production.
+1. Roll traffic back to the previous stable image/revision
+2. Revert only the failing application change
+3. Re-run smoke tests on the restored version
+4. Investigate root cause before retrying deployment

--- a/README.md
+++ b/README.md
@@ -1,428 +1,63 @@
-# Quote Tool
+# Employee Expense Reporting App
 
-Quote Tool is a web app for quick freight quotes. It handles Hotshot and Air jobs for Freight Services staff and trusted partners.
-Enter ZIP codes, weight, and extras to see a price, then escalate the booking through the internal email workflows or the Freight
-Services portal.
+This repository contains a Flask-based **employee expense reporting application**.
+It helps employees submit expense reports, supervisors review and approve them,
+and administrators manage policy, users, and system settings.
 
-## Features
+> Note: The codebase also contains legacy freight-quote modules. The primary
+> product direction documented here is the employee expense workflow.
 
-- Sign up, log in, and reset passwords
-- Global request throttling protects login and password reset endpoints
-- Freight Services sign-ups using `@freightservices.net` emails are created as
-  pending employees so administrators can approve their access
-- Admin area to approve users, edit rates, and review the quote history
-- Staff-only booking helpers let approved Freight Services employees email booking or volume-pricing requests directly from a quote
-- Super admins can manage Office 365 SMTP credentials from the dashboard
-- Price engine uses Google Maps and rate tables
-- Quotes saved in a database
-- Warns when shipment weight or cost exceeds tool limits
+## What the app does
 
-## Feature status
+- Employee authentication (register, sign in, reset password)
+- Expense report creation and submission
+- Supervisor review and approval workflow
+- Admin dashboards for user and settings management
+- Audit-friendly persistence of submitted reports and status changes
 
-| Feature | Status | Notes |
-| --- | --- | --- |
-| Hotshot and Air quoting | ✅ Stable | Accepts form and JSON submissions and persists quotes. |
-| Booking email workflow (`Email to Request Booking`) | 🔒 Staff-only | Restricted to approved employees or super admins whose email matches `MAIL_PRIVILEGED_DOMAIN`. Customers see the button disabled. |
-| Volume-pricing email workflow | 🔒 Staff-only | Surfaces when a quote exceeds thresholds; limited to users with mail privileges. |
-| Quote summary emailer | 🔒 Staff-only | Enabled for Freight Services staff only. Requires SMTP credentials and mail privileges. |
-| Redis caching | ⚙️ Optional | Disabled by default. Enable with `COMPOSE_PROFILES=cache` and Redis configuration. |
+## Core user flows
 
-## Documentation hub
+1. **Employee submits a report**
+   - Create a new expense report
+   - Add expense details and submit for review
+2. **Supervisor reviews**
+   - View pending reports
+   - Approve or reject with feedback
+3. **Employee tracks status**
+   - Monitor report status and review outcomes
 
-- [Documentation Hub](docs/README.md) – Cross-reference of every guide, inline
-  comment, and help topic.
-- [Architecture](ARCHITECTURE.md) – Component breakdown and reimplementation
-  notes for porting the app to another stack.
-- [Deployment](DEPLOYMENT.md) – Production roll-out, TLS, and maintenance
-  checklists.
-- In-app Help Center (`/help`) – Task-oriented user guides rendered from
-  `templates/help/`.
+## Project structure
 
-## Quick Start (local development)
+- `flask_app.py`, `app.py`, `expenses.py`: application entrypoints and expense routes
+- `services/expense_workflow.py`: workflow logic for report lifecycle actions
+- `templates/expenses/`: employee and supervisor expense UI templates
+- `models.py`: persistence models used by authentication and expense workflows
+- `tests/`: automated tests, including expense workflow and form validation coverage
 
-1. Install Python 3.8 or newer.
-2. Copy `.env.example` to `.env` and fill in keys and database info.
-   - Generate a long random value for `SECRET_KEY` (for example,
-     `python -c 'import secrets; print(secrets.token_urlsafe(32))'`) so sessions
-     persist across restarts. Production deployments must set `SECRET_KEY`
-     explicitly; otherwise the app starts in maintenance mode and reports a
-     configuration error when `ENVIRONMENT` or `FLASK_ENV` is set to
-     `production`. Without it in development the app falls back to an ephemeral
-     key at startup.
-   - If you use Docker Compose for local development, see
-     [`docs/local_dev.md`](docs/local_dev.md) for the recommended setup and
-     `POSTGRES_HOST` overrides when running helper scripts outside Docker.
-3. Install packages: `pip install -r requirements-dev.txt`.
-4. Create tables: `alembic upgrade head`.
-5. Import ZIP and air rate data before starting the app:
-   `python scripts/import_air_rates.py path/to/rates_dir`.
-6. Seed rate tables and (optionally) create an admin user:
-   `python init_db.py` (uses the directory above by default).
-7. Run the app locally: `python flask_app.py`.
-   - For production use
-     `hypercorn --bind 0.0.0.0:${PORT:-8080} --workers 1 --access-logfile - "app.app:create_app()"`
-     (HTTP/2-capable when `h2` is installed) or the convenience launcher at
-     `./scripts/start_gunicorn.sh` for a Gunicorn-based option
-     (`PORT`, `GUNICORN_WORKERS`, and `GUNICORN_THREADS` tune concurrency).
-   - Do not add a `--factory` flag to Gunicorn; the factory is invoked via the
-     `()` syntax shown above, and Gunicorn does not recognize a `--factory`
-     option.
-   - `flask_app.py` is intended for local development only, so use the
-     production entrypoints above for deployed environments.
-   - The server reads ``FLASK_DEBUG`` (defaults to ``false``) to control
-     debugging. Set ``FLASK_DEBUG=true`` while developing locally and leave it
-     unset or ``false`` in production so the hardened configuration stays in
-     effect.
-8. On first run, visit `/setup` to confirm environment variables, optionally
-   save missing values (including database connection settings) into the app's
-   settings table, initialize the database schema, and create the initial super
-   admin account. When required environment variables are missing, requests
-   redirect to the setup checklist instead of a generic 500 page so operators
-   can resolve the configuration. Database connection changes take effect after
-   restarting the app. The setup flow locks down the rest of the app until a
-   user exists.
+## Local development
 
-### Database migrations
-
-Generate new Alembic migrations with the helper script, which accepts a message
-argument or prompts you interactively:
-
-```bash
-./scripts/make_migration.sh "describe change"
-```
-
-Run `alembic upgrade head` after creating a revision to apply it locally.
-
-Alembic uses the app's `SQLALCHEMY_DATABASE_URI` setting when running online
-migrations. If the URL contains percent-encoded values, the migration setup
-escapes `%` so ConfigParser interpolation does not corrupt the URL.
-
-### Docker (production-style container)
-
-1. Build the container image:
+1. Use **Python 3.8+**
+2. Install dependencies:
    ```bash
-   docker build -t quote-tool:latest .
+   pip install -r requirements-dev.txt
    ```
-2. Run the container, providing the environment settings from your `.env`
-   (including database configuration and API keys):
+3. Configure environment variables (`.env`) for database, secret key, and app settings
+4. Run database setup/migrations as needed
+5. Start the app locally:
    ```bash
-   docker run --rm -p 8080:8080 --env-file .env quote-tool:latest
+   python flask_app.py
    ```
+6. Open the app in your browser and navigate to the expense reporting pages
 
-The container starts Gunicorn with the Flask application factory. It listens on
-`$PORT` (defaults to `8080`) and requires the same environment variables as the
-non-containerized deployment paths described above.
+## Testing
 
-### Cloud Run + Cloud SQL
-
-Cloud Run requires an external PostgreSQL database; the app starts in
-maintenance mode and reports a configuration error in production without a
-valid Postgres DSN. Configure Cloud SQL using one of these options:
-
-- **TCP** – Provide `DATABASE_URL` with a PostgreSQL DSN (recommended) or set
-  `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and
-  `POSTGRES_DB`. Add `POSTGRES_OPTIONS=sslmode=require` when connecting over a
-  public IP.
-- **Unix socket** – Set `CLOUD_SQL_CONNECTION_NAME` alongside
-  `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`. Cloud Run mounts the
-  socket at `/cloudsql/<connection-name>`, and the app builds the socket-based
-  DSN automatically with the socket path preserved (no `%2F` encoding in the
-  host query parameter). Optional `POSTGRES_OPTIONS` are appended as query
-  parameters.
-
-Use `./scripts/setup_gcp.sh PROJECT_ID` to bootstrap required Google Cloud
-services, an Artifact Registry repo, and a Cloud SQL Postgres instance with
-the `quote_tool` database. Set `REGION` (defaults to `us-central1`),
-`CLOUD_SQL_INSTANCE_NAME`, `ARTIFACT_REPO_NAME`, or `POSTGRES_PASSWORD` to
-override defaults before running the script.
-
-For the Quote Tool Cloud SQL instance, configure either of the following:
-
-```bash
-# Public IP (TCP)
-POSTGRES_HOST=104.198.53.60
-POSTGRES_PORT=5432
-POSTGRES_OPTIONS=sslmode=require
-```
-
-```bash
-# Cloud Run Unix socket
-CLOUD_SQL_CONNECTION_NAME=quote-tool-483716:us-central1:quotetool-postgres-instance
-```
-
-Use a Cloud SQL **PostgreSQL** instance; MySQL is not supported by the
-application's SQLAlchemy configuration.
-
-If Cloud Run start-ups are timing out while waiting on database connectivity,
-set `STARTUP_DB_CHECKS=false` to skip migrations and table inspection during
-boot. This speeds container readiness but requires you to run migrations (for
-example, `alembic upgrade head`) separately and validate connectivity via the
-`/healthz` endpoint once the database is online.
-
-When configuration validation fails, operators can opt into diagnostics by
-setting `SHOW_CONFIG_ERRORS=true`. In non-production environments the app
-exposes configuration error details in the 500 error page and via the
-`/healthz/config` endpoint. Production deployments only expose this diagnostic
-data when the explicit opt-in flag is enabled.
-
-### Windows executable
-
-Administrators who prefer a self-contained Windows build can package the app
-with PyInstaller. The Dockerfile at `Dockerfile.windows` runs the following
-command to produce `windows_setup.exe` and embed the rate CSV fixtures alongside
-the launcher:
-
-```powershell
-pyinstaller --noconfirm --onefile --name windows_setup `
-  --add-data ".env.example;." `
-  --add-data "Hotshot_Rates.csv;rates" `
-  --add-data "beyond_price.csv;rates" `
-  --add-data "accessorial_cost.csv;rates" `
-  --add-data "Zipcode_Zones.csv;rates" `
-  --add-data "cost_zone_table.csv;rates" `
-  --add-data "air_cost_zone.csv;rates" `
-  windows_setup.py
-```
-
-Launching `windows_setup.exe` (or the copied `run_app.exe`) walks through a
-guided configuration that collects:
-
-- `ADMIN_EMAIL` for the initial administrator account.
-- `ADMIN_PASSWORD`, entered securely with `getpass` so it is not echoed back.
-- `GOOGLE_MAPS_API_KEY` used by address validation and quoting forms.
-- `SECRET_KEY`, with the option to press Enter and let the launcher generate a
-  new random key.
-
-The answers are written to a `.env` file that lives beside the executable. Rerun
-the prompts at any time with `windows_setup.exe --reconfigure`; leaving the
-`SECRET_KEY` blank during reconfiguration rotates it to a freshly generated
-value.
-
-On first launch the executable seeds the database by invoking
-[`init_db.initialize_database`](init_db.py#L82). The bundled rate data includes
-`Hotshot_Rates.csv`, `beyond_price.csv`, `accessorial_cost.csv`,
-`Zipcode_Zones.csv`, `cost_zone_table.csv`, and `air_cost_zone.csv`. Replace the
-CSV files in the `rates` directory next to the executable (or its
-`resources\rates` extraction folder when frozen) to load custom pricing the next
-time you run the launcher.
-
-Security guidance:
-
-- Treat the generated `.env` as sensitive because it stores administrator
-  credentials and API keys. Restrict NTFS permissions to the operations team and
-  keep a copy in an enterprise secret vault rather than on shared drives.
-- Rotate the Flask `SECRET_KEY` if the `.env` might have leaked. Run
-  `windows_setup.exe --reconfigure` and press Enter when prompted for the key to
-  create a new one.
-- Update credentials recorded in `.env` (for example, `ADMIN_PASSWORD`) through
-  your password manager, then rerun the launcher to synchronize the file.
-- Review the docstring of
-  [`init_db.initialize_database`](init_db.py#L82) for additional background on
-  how seeding works and what tables are touched so you can plan migrations and
-  audits accordingly.
-
-### Testing
-
-Run the automated test suite with [pytest](https://docs.pytest.org/) after you
-install the development dependencies and configure your environment variables.
-From the project root, execute:
+Run the full test suite before committing:
 
 ```bash
 pytest
 ```
 
-This command discovers and runs all tests in the `tests/` directory. Use it to
-verify changes before deploying or opening a pull request. Production builds
-should continue to install only `requirements.txt`.
+## Additional docs
 
-### Rate limiting
-
-The application uses [Flask-Limiter](https://flask-limiter.readthedocs.io/) to
-throttle abusive traffic. By default each client IP may perform up to 200
-requests per day and 50 per hour, while the `/login` and `/reset` endpoints are
-restricted to five POST attempts per minute for a given IP and email
-combination. Override the defaults with environment variables as needed:
-
-| Variable | Purpose | Default |
-| --- | --- | --- |
-| `RATELIMIT_DEFAULT` | Global limits applied to all routes | `200 per day;50 per hour` |
-| `RATELIMIT_STORAGE_URI` | Backend storage for counters | `memory://` |
-| `AUTH_LOGIN_RATE_LIMIT` | Per-user/IP throttle for `/login` | `5 per minute` |
-| `AUTH_RESET_RATE_LIMIT` | Per-user/IP throttle for `/reset` | `5 per minute` |
-| `AUTH_RESET_TOKEN_RATE_LIMIT` | Frequency cap for issuing password reset tokens | `1 per 15 minutes` |
-
-Set `RATELIMIT_HEADERS_ENABLED=true` to expose standard rate-limit headers if
-your proxy or monitoring stack expects them.
-
-### Rate CSV formats
-
-The `Zipcode_Zones.csv` file must include a header row with these columns in
-order:
-
-1. `Zipcode`
-2. `Dest Zone`
-3. `BEYOND`
-
-Headers must match exactly; missing or transposed columns will cause the import
-script to raise an error.
-
-### Local development (Docker)
-For local Docker and Docker Compose workflows, see
-[`docs/local_dev.md`](docs/local_dev.md).
-
-### Bulk seeding user accounts
-
-Use `scripts/seed_users.py` when you need to load several accounts at once.
-The repository root contains `users_seed_template.csv` with two example rows.
-Copy the file, replace the placeholder values, and run the script:
-
-```bash
-python scripts/seed_users.py --file path/to/your_users.csv
-```
-
-Passwords must either satisfy the complexity rules enforced by
-`services.auth_utils.is_valid_password` or be pre-hashed values generated by
-`werkzeug.security.generate_password_hash`. Set `--update-existing` to modify
-accounts that already exist and `--dry-run` to validate the CSV without writing
-changes. The script automatically upgrades records flagged with
-`is_admin=TRUE` to the `super_admin` role and ensures employee approvals align
-with the selected role.
-
-> ⚠️ Leave ``FLASK_DEBUG`` unset (the default) in production deployments. Turning
-> it on exposes the Werkzeug debugger and prevents Gunicorn from running with
-> the hardened configuration.
-
-### Cloud Run ingress and TLS
-
-Cloud Run terminates TLS for you and controls inbound access through ingress
-settings. When you deploy the container image to Cloud Run, choose the ingress
-mode that matches your access requirements:
-
-1. **Public ingress** – Select **Allow all traffic** to expose the service
-   publicly with a default `https://` URL.
-2. **Private ingress** – Select **Internal** or **Internal and Cloud Load
-   Balancing** if you want to restrict access to VPC-only traffic or a
-   dedicated external load balancer.
-3. **Custom domains and TLS** – Use Cloud Run's **Domain mappings** or an
-   HTTPS load balancer to attach your hostname. Google-managed certificates
-   handle TLS issuance and renewal automatically.
-
-#### Configure environment variables
-
-Set production configuration in Cloud Run (or through a CI/CD system that
-targets Cloud Run). Store secrets in Secret Manager and reference them in the
-service configuration:
-
-```dotenv
-FLASK_DEBUG=false
-GOOGLE_MAPS_API_KEY=your_google_key
-DATABASE_URL=postgresql+psycopg2://user:password@db/quote_tool
-# Generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'
-SECRET_KEY=super_secret_value
-# Generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'
-API_AUTH_TOKEN=replace_with_api_token
-# Optional: override the default API rate limit (e.g., "30 per minute")
-API_QUOTE_RATE_LIMIT=30 per minute
-```
-
-When targeting an external PostgreSQL instance (for example, Google Cloud SQL)
-leave ``DATABASE_URL`` unset and provide the individual ``POSTGRES_*`` values
-instead. The configuration helper automatically percent-encodes credentials so
-passwords containing characters such as ``?`` or ``@`` do not break the
-connection string. Optional ``POSTGRES_OPTIONS`` accepts a query-string-style
-value that is appended to the generated URI, enabling flags like
-``sslmode=require`` without manually editing the DSN:
-
-```dotenv
-POSTGRES_USER=quote_tool
-POSTGRES_PASSWORD=ChangeMeSuperSecret!
-POSTGRES_DB=quote_tool
-POSTGRES_HOST=34.132.95.126
-POSTGRES_PORT=5432
-POSTGRES_OPTIONS=sslmode=require&application_name=quote-tool
-```
-
-> Replace the example password with your real secret. Because
-> ``POSTGRES_PASSWORD`` is encoded automatically, special characters do not need
-> manual escaping.
-
-PostgreSQL configuration is required in all environments. If no PostgreSQL
-settings are supplied, the application starts in maintenance mode and surfaces
-a configuration error. Provide `DATABASE_URL` or the `POSTGRES_*` environment
-variables before launching the service.
-
-#### Cloud Run TLS guidance
-
-Cloud Run provisions managed TLS certificates automatically. For custom
-domains, map the domain in Cloud Run or point an external HTTPS load balancer
-at the service. The load balancer configuration also lets you layer on Cloud
-Armor policies or IAP if you need additional access control beyond Cloud Run's
-ingress settings.
-
-## Advanced
-
-- Run only the JSON API: `python standalone_flask_app.py`.
-- Import rate data any time with the same script as above.
-- Admin pages let you manage rate tables and fuel surcharges.
-
-### JSON API authentication
-
-The JSON API requires an API token in the `Authorization` header for every
-request. Configure the token with `API_AUTH_TOKEN` and provide it as a bearer
-token:
-
-```bash
-curl -H "Authorization: Bearer ${API_AUTH_TOKEN}" \
-  http://localhost:5000/api/quote
-```
-
-Rate limiting for `/api/quote` endpoints is controlled with
-`API_QUOTE_RATE_LIMIT` (defaults to `30 per minute`). Adjust the limiter
-storage backend using `RATELIMIT_STORAGE_URI` if you need shared counters
-across multiple workers.
-
-## Troubleshooting
-
-If you see `no such table` errors, the database is missing required tables.
-Confirm the PostgreSQL connection details are correct, then run
-`alembic upgrade head` to apply migrations. If you are initializing a fresh
-environment, set `ADMIN_EMAIL` and `ADMIN_PASSWORD` in `.env` (the script loads
-this file automatically), then run `python init_db.py` to seed the schema.
-
-If quotes warn that "Air rate table(s) missing or empty", ensure the CSV
-directory is present or specify its path via `RATE_DATA_DIR` before initializing
-the database.
-
-## Architecture
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for an overview of the application's components and guidance on rebuilding the app in another stack.
-
-## Expense workflow implementation reference
-
-The expense module is built from the workbook in the repository root:
-
-- `Dave Alexander Expense Report 12.12.2023.xlsx`
-
-Use the following sheets as implementation references:
-
-- **Blank Expense Report**: Mirrors the web line-entry layout (Date, Type,
-  Account, Description, Company/Names, Amount, Receipt Link).
-- **GL Accounts**: Source for GL account search/dropdown values so each line is
-  pre-coded for NetSuite.
-- **Data List**: Source of standard expense type categories.
-
-### Expense reimbursement policy highlights used by the app
-
-- Meal receipts are required; when missing, meal reimbursement caps apply
-  (Breakfast `$10`, Lunch `$15`, Dinner `$25`).
-- Mileage reimbursement should use the IRS rate for miles beyond base commute.
-- Domestic airfare reimbursement is coach-only.
-- International airfare may use business class only for continuous flights over
-  8 hours.
-- Car rental defaults to compact class; mid-size requires multi-employee travel
-  or exception.
-- Laundry reimbursement applies only for trips longer than 7 full days.
-- Non-reimbursable categories include traffic fines, personal sundries, and
-  personal entertainment.
-- Approval path is supervisor review first, then Vice President of Operations
-  approval before final upload.
+- [ARCHITECTURE.md](ARCHITECTURE.md): technical architecture focused on expense reporting
+- [DEPLOYMENT.md](DEPLOYMENT.md): deployment guide for running this app in production


### PR DESCRIPTION
### Motivation
- The repository's public-facing documentation referenced a freight-quote product; the project is primarily an employee expense reporting application and the docs should reflect that product focus.
- Clarify primary user roles and flows (employee → supervisor → admin) to make onboarding and operations guidance explicit.
- Surface where legacy freight-quote modules remain so maintainers can identify non-primary code areas.

### Description
- Rewrote `README.md` into an `Employee Expense Reporting App` overview that outlines user roles, core flows, project structure, local development steps, and testing guidance.
- Rewrote `DEPLOYMENT.md` into a focused deployment runbook for the expense-reporting app that includes runtime requirements, required environment configuration, container and start commands, smoke checks, security notes, and rollback guidance.
- Rewrote `ARCHITECTURE.md` to document the expense-reporting architecture, layered components (`Web/UI`, `Workflow/service`, `Data`), request flow, templates, and testing focus while noting legacy freight modules are still present.
- Updated doc cross-references to point to the expense-focused docs and left implementation and testing guidance (`pytest`) intact for maintainers.

### Testing
- Ran the full test suite with `pytest` locally: `pytest`.
- Test run failed during collection with 7 errors caused by import-time `ImportError: attempted relative import with no known parent package` originating from package import paths (errors surfaced while importing `/workspace/EXPENSES/__init__.py`), which is unrelated to these documentation-only changes.
- No automated tests were modified by this PR and no new tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984c3cbd8948333a40f1f1c708875ec)