### PR TITLE
docs: clarify Cloud Build deploy flow and post-deploy validation

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,7 +19,32 @@ Set these values through environment variables or your secret manager:
 - Mail/settings values used by your environment (if enabled)
 - Any app-specific authentication or integration settings in your deployment profile
 
-## 3. Build and install
+## 3. Cloud Build trigger flow (current production path)
+
+The Cloud Build trigger defined in `cloudbuild.yaml` deploys Cloud Run in this
+exact order:
+
+1. **Build image** using Docker:
+   ```bash
+   docker build -f Dockerfile -t ${_IMAGE_URI} .
+   ```
+2. **Push image** to Artifact Registry:
+   ```bash
+   docker push ${_IMAGE_URI}
+   ```
+3. **Resolve digest and deploy the same image by digest** to service
+   `${_SERVICE}` (currently `expenses`):
+   - Resolve digest from `${_IMAGE_URI}`
+   - Build immutable deploy reference `${_IMAGE_REPO}@${DIGEST}`
+   - Deploy with:
+     ```bash
+     gcloud run deploy ${_SERVICE} --image=${_IMAGE_REPO}@${DIGEST}
+     ```
+
+This ensures the image that was built and pushed is exactly the image revision
+deployed to Cloud Run.
+
+## 4. Build and install (local/manual alternatives)
 
 ### Option A: standard host/VM deploy
 
@@ -41,7 +66,7 @@ Run with environment variables:
 docker run --rm -p 8080:8080 --env-file .env expense-reporting-app:latest
 ```
 
-## 4. Start command
+## 5. Start command
 
 Use a production WSGI/ASGI runner instead of the development server.
 Example Gunicorn-style startup:
@@ -53,7 +78,7 @@ Example Gunicorn-style startup:
 or an equivalent command that invokes the Flask app factory/module used in your
 infrastructure.
 
-## 5. Pre-release checklist
+## 6. Pre-release checklist
 
 Before promoting a release:
 
@@ -66,7 +91,42 @@ Before promoting a release:
 4. Confirm supervisor review actions (approve/reject) work
 5. Confirm admin dashboard access/permissions are correct
 
-## 6. Post-deploy smoke tests
+## 7. Mandatory post-deploy validation checks
+
+Run these checks after each deploy to `${_SERVICE}` in `${_REGION}` for
+`${_PROJECT_ID}`:
+
+1. **Active revision image URI**
+   - Verify the deployed image is digest-pinned and not a placeholder image:
+     ```bash
+     gcloud run services describe "${_SERVICE}" \
+       --region="${_REGION}" \
+       --project="${_PROJECT_ID}" \
+       --format='value(spec.template.spec.containers[0].image)'
+     ```
+   - Expected format: `${_IMAGE_REPO}@sha256:...`
+
+2. **Environment variable and secret presence**
+   - Validate required runtime env vars exist (`ENVIRONMENT`, `FLASK_DEBUG`,
+     `STARTUP_DB_CHECKS`, `HEALTHCHECK_REQUIRE_DB`).
+   - Validate required secrets are attached (`SECRET_KEY`,
+     `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER`,
+     `OIDC_AUDIENCE`, `NETSUITE_SFTP_PASSWORD`,
+     `NETSUITE_SFTP_PRIVATE_KEY`, `NETSUITE_SFTP_PRIVATE_KEY_PASSPHRASE`,
+     `DATABASE_URL`).
+
+3. **Cloud SQL connection status**
+   - Confirm Cloud Run service includes
+     `${_CLOUD_SQL_CONNECTION_NAME}` in its Cloud SQL instance connections.
+
+4. **Health endpoint response**
+   - Confirm service responds successfully on the health endpoint (and, if
+     configured, DB-backed health checks pass):
+     ```bash
+     curl -fsS "https://<service-url>/health"
+     ```
+
+## 8. Post-deploy smoke tests
 
 After deployment:
 
@@ -75,7 +135,32 @@ After deployment:
 - Review and approve/reject it as a supervisor user
 - Confirm report status updates are visible to the employee
 
-## 7. Security and operations notes
+## 9. Troubleshooting placeholder image symptoms
+
+### Symptom
+
+- `verify-deployed-image` fails.
+- Deployed image is `gcr.io/cloudrun/placeholder...` or not
+  `${_IMAGE_REPO}@sha256:...`.
+
+### Most likely root causes
+
+1. **Missing or incorrect `Dockerfile`**
+   - The build step (`docker build -f Dockerfile ...`) failed or built an
+     unexpected image.
+2. **Wrong `${_IMAGE_URI}`**
+   - Build/push target does not match the expected Artifact Registry path.
+3. **Wrong `${_SERVICE}`**
+   - Deployment updated a different Cloud Run service than intended.
+4. **Push/deploy permission failure**
+   - Cloud Build service account lacks required permissions to push the image
+     or deploy Cloud Run.
+
+When diagnosing, confirm build logs, push logs, digest resolution output, and
+`gcloud run services describe "${_SERVICE}"` all reference the same values for
+`${_PROJECT_ID}`, `${_REGION}`, `${_IMAGE_URI}`, and `${_IMAGE_REPO}`.
+
+## 10. Security and operations notes
 
 - Store secrets in a secret manager; do not commit secrets to git
 - Enforce HTTPS/TLS at the load balancer or ingress layer
@@ -83,7 +168,7 @@ After deployment:
 - Enable application logging/monitoring for workflow and auth failures
 - Back up the production database and define a tested restore process
 
-## 8. Rollback strategy
+## 11. Rollback strategy
 
 If deployment fails:
 


### PR DESCRIPTION
### Motivation

- Make the deployment guide authoritative and operator-proof by documenting the exact Cloud Build trigger flow as implemented in `cloudbuild.yaml` so operators deploy the same immutable image that was built and pushed. 
- Provide mandatory post-deploy validation and troubleshooting guidance to catch common production problems (placeholder images, missing secrets, DB connections) quickly.

### Description

- Updated `DEPLOYMENT.md` to document the Cloud Build trigger flow step-for-step including `docker build -f Dockerfile -t ${_IMAGE_URI} .`, `docker push ${_IMAGE_URI}`, digest resolution, and deploying the resolved `${_IMAGE_REPO}@${DIGEST}` to the Cloud Run service `${_SERVICE}`. 
- Added a mandatory post-deploy validation checklist covering active revision image URI verification, runtime environment variable/secret presence, Cloud SQL connection attachment, and health endpoint checks with example `gcloud` and `curl` commands. 
- Added a troubleshooting section for placeholder-image symptoms listing the most likely root causes (`Dockerfile` issues, wrong `_IMAGE_URI`, wrong `_SERVICE`, and push/deploy permission failures) and guidance to cross-check build/push/digest/deploy outputs. 
- Kept variable names and examples consistent with `cloudbuild.yaml` substitutions and renumbered downstream document sections to preserve flow.

### Testing

- Ran the full test suite with `pytest`; test collection failed with import errors unrelated to this docs-only change (errors during module import due to existing relative-import issues), so no test failures were introduced by this documentation change. 
- No new dependencies or migrations were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984c4a745708333b9626e8bf8b3769d)