### PR TITLE
Fix scripts import crash and Cloud SQL psycopg2 socket URI

### DIFF
--- a/config.py
+++ b/config.py
@@ -322,11 +322,11 @@ def _select_postgres_database_uri(
         "PostgreSQL database configuration is required. Set DATABASE_URL or "
         "POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, and POSTGRES_HOST."
     )
-    return "postgresql+pg8000://localhost/postgres"
+    return "postgresql+psycopg2://localhost/postgres"
 
 
 def build_postgres_database_uri_from_env(
-    *, driver: str = "postgresql+pg8000"
+    *, driver: str = "postgresql+psycopg2"
 ) -> Optional[str]:
     """Assemble a PostgreSQL SQLAlchemy URI based on Compose-style environment variables.
 
@@ -381,7 +381,7 @@ def build_postgres_database_uri_from_env(
 
 
 def build_cloud_sql_unix_socket_uri_from_env(
-    *, driver: str = "postgresql+pg8000"
+    *, driver: str = "postgresql+psycopg2"
 ) -> Optional[str]:
     """Assemble a PostgreSQL SQLAlchemy URI for a Cloud SQL Unix socket.
 
@@ -390,13 +390,15 @@ def build_cloud_sql_unix_socket_uri_from_env(
     ``POSTGRES_*`` credentials, this helper builds a SQLAlchemy URI that points
     at the Unix socket path. Optional ``POSTGRES_OPTIONS`` values are appended
     as query parameters so SSL settings or application names can be enforced.
+    The query uses the ``host`` parameter pointed at the socket directory (not
+    the ``.s.PGSQL.5432`` file) because psycopg2 expects a directory path.
     The socket path is preserved with literal slashes to avoid a ``%2F``
     sequence in the resulting DSN while still safely encoding other query
     parameter values.
 
     Args:
         driver: SQLAlchemy driver prefix used when constructing the URI. The
-            default matches the ``pg8000`` driver required by
+            default matches the ``psycopg2`` driver required by
             :mod:`sqlalchemy` for PostgreSQL connections.
 
     Returns:
@@ -427,10 +429,10 @@ def build_cloud_sql_unix_socket_uri_from_env(
     if options:
         query_pairs.extend(_parse_postgres_options(options))
 
-    query_pairs.append(("unix_sock", f"/cloudsql/{connection_name}/.s.PGSQL.5432"))
-    query = urlencode(query_pairs, safe="/")
+    query_pairs.append(("host", f"/cloudsql/{connection_name}"))
+    query = urlencode(query_pairs, safe="/:")
     return (
-        f"{driver}://{quote_plus(user)}:{quote_plus(password).replace('%', '%%')}@/"
+        f"{driver}://{quote_plus(user)}:{quote_plus(password)}@/"
         f"{quote_plus(db_name)}?{query}"
     )
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for data import workflows used by the admin interface."""

--- a/scripts/import_air_rates.py
+++ b/scripts/import_air_rates.py
@@ -1,0 +1,58 @@
+"""Helpers used by admin CSV upload workflows.
+
+This module currently exposes ``save_unique`` so ``app.admin.upload_csv`` can
+append rows while skipping duplicates based on a model attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Tuple, Type
+
+from sqlalchemy.orm import Session
+
+
+def save_unique(
+    session: Session,
+    model: Type[Any],
+    objects: Iterable[Any],
+    unique_attr: str,
+) -> Tuple[int, int]:
+    """Persist only rows whose unique key is not already present.
+
+    Inputs:
+        session: Active SQLAlchemy session used to query and persist records.
+            The caller (``app.admin.upload_csv``) controls transaction commit.
+        model: SQLAlchemy model class associated with ``objects``.
+        objects: Candidate model instances to insert.
+        unique_attr: Name of the model attribute used as a de-duplication key.
+
+    Outputs:
+        Tuple[int, int]: ``(inserted_count, skipped_count)`` describing how
+        many rows were saved versus ignored as duplicates.
+
+    External dependencies:
+        Calls ``sqlalchemy.orm.Session.query`` against ``model`` to load
+        existing key values and ``session.bulk_save_objects`` to insert only
+        unseen rows.
+    """
+
+    existing_values = {
+        value
+        for (value,) in session.query(getattr(model, unique_attr)).all()
+        if value is not None
+    }
+
+    unique_objects = []
+    skipped = 0
+    for obj in objects:
+        value = getattr(obj, unique_attr, None)
+        if value in existing_values:
+            skipped += 1
+            continue
+        existing_values.add(value)
+        unique_objects.append(obj)
+
+    if unique_objects:
+        session.bulk_save_objects(unique_objects)
+
+    return len(unique_objects), skipped

--- a/tests/test_cloud_sql_uri.py
+++ b/tests/test_cloud_sql_uri.py
@@ -1,0 +1,48 @@
+"""Tests for Cloud SQL URI assembly and scripts package imports."""
+
+from scripts.import_air_rates import save_unique
+
+from config import build_cloud_sql_unix_socket_uri_from_env
+
+
+def test_cloud_sql_uri_uses_psycopg2_host_directory(monkeypatch):
+    """Build a psycopg2 DSN that points ``host`` to the socket directory.
+
+    Inputs:
+        monkeypatch: pytest fixture used to set Cloud SQL env variables.
+
+    Outputs:
+        None. Asserts the generated DSN shape expected by psycopg2.
+
+    External dependencies:
+        Calls ``config.build_cloud_sql_unix_socket_uri_from_env``.
+    """
+
+    monkeypatch.setenv("CLOUD_SQL_CONNECTION_NAME", "project-1:us-central1:expenses-db")
+    monkeypatch.setenv("POSTGRES_USER", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "abc&123")
+    monkeypatch.setenv("POSTGRES_DB", "postgres")
+
+    uri = build_cloud_sql_unix_socket_uri_from_env()
+
+    assert uri is not None
+    assert uri.startswith("postgresql+psycopg2://")
+    assert "abc%26123" in uri
+    assert "host=/cloudsql/project-1:us-central1:expenses-db" in uri
+    assert "unix_sock=" not in uri
+
+
+def test_scripts_package_is_importable_and_exposes_save_unique():
+    """Confirm the scripts package resolves and exposes ``save_unique``.
+
+    Inputs:
+        None.
+
+    Outputs:
+        None. Asserts the imported symbol is callable.
+
+    External dependencies:
+        Imports ``scripts.import_air_rates.save_unique``.
+    """
+
+    assert callable(save_unique)


### PR DESCRIPTION
### Motivation
- Resolve a startup `ModuleNotFoundError` caused by missing `scripts` package so runtime imports like `scripts.import_air_rates` succeed.  
- Make Cloud SQL connections compatible with `psycopg2` by pointing the DSN `host` at the socket directory instead of the specific socket file.  
- Ensure passwords containing special characters (e.g., `&`) are URL-encoded correctly in generated DSNs.

### Description
- Added a lightweight package marker `scripts/__init__.py` so `scripts.*` imports are discoverable at runtime.  
- Implemented `scripts/import_air_rates.py` exposing a typed `save_unique(session, model, objects, unique_attr)` helper used by `app.admin.upload_csv` to bulk-insert rows while skipping duplicates.  
- Updated `config.py` to prefer `postgresql+psycopg2` and changed `build_cloud_sql_unix_socket_uri_from_env` to emit `host=/cloudsql/<connection_name>` (directory) and to preserve proper URL-encoding of credentials.  
- Added `tests/test_cloud_sql_uri.py` which verifies the Cloud SQL DSN shape for `psycopg2` and that `save_unique` is importable.

### Testing
- Ran the full test suite with `pytest` and verified all tests passed: `9 passed`.  
- Added and ran the new test `tests/test_cloud_sql_uri.py`, which passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984e15e45248333b6ef75c93a6949eb)