### PR TITLE
Remove quote-tool bootstrapping from Flask app factory

### DIFF
--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -1,0 +1,22 @@
+"""Tests for quote-tool route removal in the app factory module."""
+
+from pathlib import Path
+
+
+def test_quote_tool_routes_are_not_defined_in_app_init() -> None:
+    """Verify quote-tool routes are absent from ``app/__init__.py``.
+
+    Inputs:
+        None. Reads ``app/__init__.py`` from disk.
+
+    Outputs:
+        None. Asserts the removed route decorators are no longer present.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    init_source = Path("app/__init__.py").read_text(encoding="utf-8")
+
+    assert '@app.route("/map", methods=["POST"])' not in init_source
+    assert '@app.route("/send", methods=["POST"])' not in init_source


### PR DESCRIPTION
### Motivation

- Remove legacy quote-tool bootstrapping that is not used by the expense tracking app to reduce surface area and maintenance burden.
- Eliminate route handlers and imports tied to quote email/map functionality which are not part of current application responsibilities.
- Keep startup template and setup validation focused on shared app templates instead of quote-only templates.

### Description

- Deleted quote blueprint imports and registrations for `quotes_bp` and `admin_quotes_bp` from `app/__init__.py` so quote blueprints are no longer bootstrapped.
- Removed the `/map` and `/send` route handlers and the `build_map_html` helper so the app no longer builds or emails quotes.
- Removed now-unused imports and symbols tied to the removed handlers (`flash`, `current_user`, `login_required`, `Markup`, `datetime`, `get_distance_miles`, and quote-mail-related mail helpers).
- Updated the `create_app` docstring from quote-tool wording to expense-tracking wording and trimmed `required_templates` to `index.html` and `500.html` only.
- Added a regression test `tests/test_app_routes.py` that asserts the `/map` and `/send` route decorators are no longer present in `app/__init__.py` and ran `black` on modified files.

### Testing

- Ran code formatting with `black` and it completed successfully on modified files.
- Ran the full test suite with `pytest`: 10 tests were collected, 9 passed and 1 failed; the failing test is `tests/test_cloud_sql_uri.py::test_cloud_sql_uri_uses_psycopg2_host_directory` which is an existing environment/driver expectation mismatch (the runtime produced a `pg8000` URI rather than the expected `psycopg2` scheme) and is unrelated to the quote-tool removal; the new `tests/test_app_routes.py` regression test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984e5d11d14833382cf554eadcf6057)