### PR TITLE
Deprecate quote API endpoints and align API to expense-only scope

### DIFF
--- a/tests/test_api_quote_deprecation.py
+++ b/tests/test_api_quote_deprecation.py
@@ -1,0 +1,87 @@
+"""Regression tests for deprecated quote API endpoints in ``app.api``."""
+
+from __future__ import annotations
+
+from flask import Flask
+from flask.testing import FlaskClient
+
+from app.api import api_bp
+
+
+def _make_client(api_token: str = "test-token") -> FlaskClient:
+    """Create a minimal Flask test client with the API blueprint registered.
+
+    Args:
+        api_token: Shared bearer token written to ``API_AUTH_TOKEN`` for
+            :func:`app.api._authorize_api_request`.
+
+    Returns:
+        Flask test client bound to an in-memory application.
+
+    External dependencies:
+        Calls :func:`flask.Flask.register_blueprint` to mount :data:`app.api.api_bp`.
+    """
+
+    app = Flask(__name__)
+    app.config["API_AUTH_TOKEN"] = api_token
+    app.register_blueprint(api_bp, url_prefix="/api")
+    return app.test_client()
+
+
+def test_quote_create_endpoint_returns_410_with_migration_message() -> None:
+    """Ensure legacy quote-create route provides explicit migration guidance.
+
+    Inputs:
+        None. Sends an authenticated ``POST`` request to ``/api/quote``.
+
+    Outputs:
+        Verifies ``410`` response status and migration fields in JSON payload.
+
+    External dependencies:
+        Exercises :func:`app.api.api_create_quote` through Flask routing.
+    """
+
+    client = _make_client()
+
+    response = client.post("/api/quote", headers={"Authorization": "Bearer test-token"})
+
+    assert response.status_code == 410
+    assert response.json == {
+        "error": "Quote API has been removed.",
+        "message": (
+            "This service now supports expense-report workflows only. "
+            "Migrate integrations away from /api/quote endpoints."
+        ),
+        "migration_path": "/expenses",
+    }
+
+
+def test_quote_get_endpoint_returns_410_with_migration_message() -> None:
+    """Ensure legacy quote-read route provides explicit migration guidance.
+
+    Inputs:
+        None. Sends an authenticated ``GET`` request to
+        ``/api/quote/<quote_id>``.
+
+    Outputs:
+        Verifies ``410`` response status and migration fields in JSON payload.
+
+    External dependencies:
+        Exercises :func:`app.api.api_get_quote` through Flask routing.
+    """
+
+    client = _make_client()
+
+    response = client.get(
+        "/api/quote/legacy-quote-id", headers={"Authorization": "Bearer test-token"}
+    )
+
+    assert response.status_code == 410
+    assert response.json == {
+        "error": "Quote API has been removed.",
+        "message": (
+            "This service now supports expense-report workflows only. "
+            "Migrate integrations away from /api/quote endpoints."
+        ),
+        "migration_path": "/expenses",
+    }


### PR DESCRIPTION
### Motivation
- The project is being scoped to expense-report functionality so the legacy quote endpoints and service coupling should be removed from the JSON API surface. 
- Existing integrations may still call `/api/quote*`, so provide explicit, actionable responses rather than leaving them broken. 

### Description
- Removed `from app.services import quote as quote_service` and deleted quote serialization and business logic, replacing it with a migration helper ` _quote_endpoint_removed_response` that returns a `410` payload.  
- Replaced `POST /api/quote` and `GET /api/quote/<quote_id>` handlers to return JSON `410 Gone` responses with migration guidance and a `"migration_path": "/expenses"` field.  
- Removed quote-specific rate-limit helpers and related config references from the module and updated the module docstring to reflect expense-report scope.  
- Added regression tests in `tests/test_api_quote_deprecation.py` that assert both deprecated endpoints return `410` and the expected migration payload. 

### Testing
- Formatted code with `black` on the new test file and module, which completed successfully.  
- Ran the full test suite with `pytest`, which executed 14 tests and all passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984e7bd471c83338dc5de531e8d1f0b)