### PR TITLE
Update UI branding to "FSI Expense Reporting"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{% block title %}Quote Tool{% endblock %}</title>
+    <title>{% block title %}FSI Expense Reporting{% endblock %}</title>
     {{ fsi_theme()|safe }}
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link
@@ -15,7 +15,7 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-light">
       <div class="container-fluid">
-        <a class="navbar-brand fw-semibold" href="/">Quote Tool</a>
+        <a class="navbar-brand fw-semibold" href="/">FSI Expense Reporting</a>
         <button
           class="navbar-toggler"
           type="button"

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -1,0 +1,23 @@
+"""Regression tests for Expense Reporting branding text in shared templates."""
+
+from pathlib import Path
+
+
+def test_base_template_uses_expense_reporting_branding() -> None:
+    """Ensure the shared base layout shows the updated application name.
+
+    Inputs:
+        None. Reads ``templates/base.html`` from disk.
+
+    Outputs:
+        None. Asserts legacy "Quote Tool" branding is removed from the
+        default page title and navbar brand label.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read template source content.
+    """
+
+    base_template_source = Path("templates/base.html").read_text(encoding="utf-8")
+
+    assert "FSI Expense Reporting" in base_template_source
+    assert "Quote Tool" not in base_template_source


### PR DESCRIPTION
### Motivation
- The application still displayed legacy "Quote Tool" branding in the shared base layout and navbar, which must be updated to the correct product name "FSI Expense Reporting" so the UI reflects the intended application identity.

### Description
- Updated `templates/base.html` to replace the default page `<title>` block from `Quote Tool` to `FSI Expense Reporting` and to change the navbar brand label to `FSI Expense Reporting`.
- Added `tests/test_branding.py` to assert the new branding appears in `templates/base.html` and the legacy `Quote Tool` text is absent.
- No code paths, dependencies, or database migrations were modified.

### Testing
- Ran the targeted test `PYTHONDONTWRITEBYTECODE=1 pytest tests/test_branding.py`, which passed. 
- Ran the full test suite with `PYTHONDONTWRITEBYTECODE=1 pytest`, which ran but reported one unrelated pre-existing failure in `tests/test_cloud_sql_uri.py::test_cloud_sql_uri_uses_sqlalchemy_cloud_sql_socket_format` while all other tests passed.
- Formatting was checked for new Python test file with `black` and succeeded for source files; HTML templates are not reformatted by `black`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984fdd39aac8333abda272de25c0a10)