### PR TITLE
Remove broken quote endpoint links and fix expense template reference

### DIFF
--- a/app/expenses.py
+++ b/app/expenses.py
@@ -212,7 +212,7 @@ def new_expense() -> str | Response:
         "expenses/new_expense.html",
         supervisors=supervisors,
         expense_types=expense_types,
-        reference_workbook="Dave Alexander Expense Report 12.12.2023.xlsx",
+        reference_workbook="expense_report_template.xlsx",
     )
 
 

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -11,9 +11,6 @@
         <a class="btn btn-warning" href="{{ settings_url }}">Settings</a>
         {% endif %}
       </div>
-      <div class="btn-group me-2 mb-2" role="group" aria-label="Quote tools">
-        <a class="btn btn-secondary" href="{{ url_for('admin_quotes.quotes_html') }}">View Quotes</a>
-      </div>
       <div class="btn-group mb-2" role="group" aria-label="Zone tools">
         <a class="btn btn-secondary" href="{{ url_for('admin.list_cost_zones') }}">Cost Zones</a>
       </div>

--- a/templates/admin_employee_dashboard.html
+++ b/templates/admin_employee_dashboard.html
@@ -3,8 +3,7 @@
 {% block content %}
 <section class="admin-dashboard text-center">
   <h1 class="mb-3">Team Quote Access</h1>
-  <p class="lead">Review stored pricing data from the internal quotes dashboard.</p>
-  <a class="btn btn-primary" href="{{ url_for('admin_quotes.quotes_html') }}">Open Quotes</a>
+  <p class="lead">Quote tools are no longer available in this application.</p>
   <p class="mt-3 text-muted">Need broader permissions? Contact a super administrator for help.</p>
 </section>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,15 +44,9 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#">Quotes</a>
-            </li>
             {% elif current_user.role == 'employee' and current_user.employee_approved %}
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('admin.dashboard') }}">Team Dashboard</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#">Quotes</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('expenses.new_expense') }}">New Expense</a>

--- a/tests/test_auth_redirect_routes.py
+++ b/tests/test_auth_redirect_routes.py
@@ -42,6 +42,8 @@ def test_repository_contains_no_quote_new_quote_references() -> None:
         Path("templates/quote_result.html"),
     ]
 
-    for file_path in files_to_check:
+    existing_files = [path for path in files_to_check if path.exists()]
+
+    for file_path in existing_files:
         content = file_path.read_text(encoding="utf-8")
         assert "quotes.new_quote" not in content

--- a/tests/test_expenses_form_validation.py
+++ b/tests/test_expenses_form_validation.py
@@ -23,3 +23,13 @@ def test_expenses_module_exposes_gl_accounts_endpoint() -> None:
 
     assert '@expenses_bp.get("/gl-accounts")' in content
     assert "select a GL account from the approved list" in content
+
+
+def test_new_expense_uses_renamed_reference_workbook() -> None:
+    """Ensure the new expense route advertises the renamed workbook template."""
+
+    module_path = Path("app/expenses.py")
+    content = module_path.read_text(encoding="utf-8")
+
+    assert 'reference_workbook="expense_report_template.xlsx"' in content
+    assert "Dave Alexander Expense Report 12.12.2023.xlsx" not in content

--- a/tests/test_legacy_quote_admin_cleanup.py
+++ b/tests/test_legacy_quote_admin_cleanup.py
@@ -6,6 +6,8 @@ from pathlib import Path
 MODELS_PATH = Path("app/models.py")
 ADMIN_PATH = Path("app/admin.py")
 DASHBOARD_TEMPLATE_PATH = Path("templates/admin_dashboard.html")
+EMPLOYEE_DASHBOARD_TEMPLATE_PATH = Path("templates/admin_employee_dashboard.html")
+BASE_TEMPLATE_PATH = Path("templates/base.html")
 MIGRATION_PATH = Path(
     "migrations/versions/20260205_01_archive_and_drop_legacy_quote_tables.py"
 )
@@ -103,3 +105,27 @@ def test_migration_archives_before_drop() -> None:
     assert "archive_" in source
     assert "CREATE TABLE" in source
     assert "op.drop_table" in source
+
+
+def test_templates_remove_admin_quotes_endpoint_references() -> None:
+    """Assert templates no longer reference the removed admin quote endpoint.
+
+    Inputs:
+        None. Reads source code from dashboard/base templates.
+
+    Outputs:
+        None. Fails if ``admin_quotes.quotes_html`` references return.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read repository files.
+    """
+
+    admin_dashboard_source = DASHBOARD_TEMPLATE_PATH.read_text(encoding="utf-8")
+    employee_dashboard_source = EMPLOYEE_DASHBOARD_TEMPLATE_PATH.read_text(
+        encoding="utf-8"
+    )
+    base_source = BASE_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert "admin_quotes.quotes_html" not in admin_dashboard_source
+    assert "admin_quotes.quotes_html" not in employee_dashboard_source
+    assert "Quotes" not in base_source


### PR DESCRIPTION
## Summary
- Removed broken `admin_quotes.quotes_html` links from admin-facing templates to prevent `BuildError` exceptions.
  - `templates/admin_dashboard.html`: removed legacy “View Quotes” button.
  - `templates/admin_employee_dashboard.html`: replaced quote-link CTA with informational text.
  - `templates/base.html`: removed stale “Quotes” navigation items.
- Updated `app/expenses.py` to pass the renamed workbook filename (`expense_report_template.xlsx`) to the new expense template.
- Added/updated regression tests to guard against reintroducing removed quote endpoint references and the legacy workbook filename.
- Hardened one repository-scan test to handle deleted optional files without raising `FileNotFoundError`.

## Testing
- Ran full test suite with `pytest`.
- Result: `24 passed`.

## Dependencies / migrations
- No new dependencies.
- No migration changes required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985270ce540833387fe6ac49bd7ab90)