### PR TITLE
Allow expense_report_template.xlsx in Docker build context and add workbook-dependent endpoint tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,3 +39,4 @@ build/
 
 # Local and large non-runtime artifacts
 *.xlsx
+!expense_report_template.xlsx

--- a/tests/test_docker_workbook_packaging.py
+++ b/tests/test_docker_workbook_packaging.py
@@ -1,0 +1,44 @@
+"""Checks for Docker packaging of the expense workbook template."""
+
+from pathlib import Path
+
+
+def test_dockerignore_allows_runtime_expense_template() -> None:
+    """Ensure Docker ignore rules include the runtime workbook exception.
+
+    Inputs:
+        None.
+
+    Outputs:
+        None. Asserts ``.dockerignore`` keeps broad ``*.xlsx`` ignores while
+        explicitly including ``expense_report_template.xlsx``.
+
+    External dependencies:
+        Reads repository files through :class:`pathlib.Path`.
+    """
+
+    dockerignore_content = Path(".dockerignore").read_text(encoding="utf-8")
+
+    assert "*.xlsx" in dockerignore_content
+    assert "!expense_report_template.xlsx" in dockerignore_content
+
+
+def test_dockerfile_copies_build_context_into_app_directory() -> None:
+    """Ensure Docker build context is copied so the workbook lands at ``/app``.
+
+    Inputs:
+        None.
+
+    Outputs:
+        None. Asserts the Dockerfile sets ``WORKDIR /app`` and executes
+        ``COPY . .`` so repository files (including the workbook template) are
+        available at runtime.
+
+    External dependencies:
+        Reads ``Dockerfile`` through :class:`pathlib.Path`.
+    """
+
+    dockerfile_content = Path("Dockerfile").read_text(encoding="utf-8")
+
+    assert "WORKDIR /app" in dockerfile_content
+    assert "COPY . ." in dockerfile_content

--- a/tests/test_expense_workbook_runtime_endpoints.py
+++ b/tests/test_expense_workbook_runtime_endpoints.py
@@ -1,0 +1,161 @@
+"""Integration tests for expense endpoints that depend on the workbook template."""
+
+from pathlib import Path
+
+import openpyxl
+
+from app import create_app
+from app.models import User, db
+import app.services.expense_workflow as expense_workflow
+
+
+class TestConfig:
+    """Minimal Flask configuration for expense endpoint integration tests.
+
+    Inputs:
+        None. Flask reads class attributes when ``app.create_app`` calls
+        ``Flask.config.from_object``.
+
+    Outputs:
+        Configuration values that keep tests isolated with an in-memory SQLite
+        database and disable startup checks that depend on external services.
+
+    External dependencies:
+        Used by :func:`app.create_app` as the configuration object.
+    """
+
+    TESTING = True
+    SECRET_KEY = "test-secret"
+    WTF_CSRF_ENABLED = False
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    STARTUP_DB_CHECKS = False
+
+
+def _build_runtime_workbook(workbook_path: Path) -> None:
+    """Create a minimal workbook with required worksheets for expense routes.
+
+    Inputs:
+        workbook_path: Filesystem location where the template workbook will be
+            written.
+
+    Outputs:
+        None. Writes an XLSX file to ``workbook_path`` containing ``GL Accounts``
+        and ``Data List`` sheets consumed by the expense workflow loaders.
+
+    External dependencies:
+        Calls :func:`openpyxl.Workbook` and ``Workbook.save``.
+    """
+
+    workbook = openpyxl.Workbook()
+
+    gl_accounts_sheet = workbook.active
+    gl_accounts_sheet.title = "GL Accounts"
+    gl_accounts_sheet.append(["Account", "Label"])
+    gl_accounts_sheet.append(["6100", "Travel Expense"])
+
+    data_list_sheet = workbook.create_sheet("Data List")
+    data_list_sheet.append(["Expense Type"])
+    data_list_sheet.append(["Meals"])
+
+    workbook_path.parent.mkdir(parents=True, exist_ok=True)
+    workbook.save(workbook_path)
+    workbook.close()
+
+
+def test_expense_endpoints_load_template_from_runtime_location(tmp_path) -> None:
+    """Verify workbook-dependent endpoints succeed for approved employees.
+
+    Inputs:
+        tmp_path: Pytest-provided temporary directory used as the simulated
+            runtime root.
+
+    Outputs:
+        None. Asserts that ``/expenses/new`` and ``/expenses/gl-accounts`` both
+        return HTTP 200 when a workbook exists at the expected runtime path.
+
+    External dependencies:
+        * Calls :func:`app.create_app`.
+        * Uses :mod:`app.models.db` to create and seed users.
+        * Calls expense workflow helpers via route handlers in
+          :mod:`app.expenses`.
+    """
+
+    runtime_root = tmp_path / "app"
+    workbook_path = runtime_root / "expense_report_template.xlsx"
+    _build_runtime_workbook(workbook_path)
+
+    app = create_app(TestConfig)
+
+    with app.app_context():
+        db.create_all()
+
+        # Remove maintenance-mode guard injected during app startup so this
+        # test can exercise endpoints after creating database tables.
+        app.before_request_funcs[None] = [
+            func
+            for func in app.before_request_funcs.get(None, [])
+            if getattr(func, "__name__", "") != "_setup_failed"
+        ]
+
+        employee = User(
+            email="employee@example.com",
+            first_name="Test",
+            last_name="Employee",
+            password_hash="hashed",
+            role="employee",
+            employee_approved=True,
+        )
+        supervisor = User(
+            email="supervisor@example.com",
+            first_name="Test",
+            last_name="Supervisor",
+            password_hash="hashed",
+            role="employee",
+            employee_approved=True,
+        )
+        db.session.add_all([employee, supervisor])
+        db.session.commit()
+
+        expense_workflow._workbook_path.cache_clear()
+        expense_workflow.load_gl_accounts.cache_clear()
+        expense_workflow.load_expense_types.cache_clear()
+
+        original_workbook_path_loader = expense_workflow._workbook_path
+
+        def _runtime_workbook_path() -> Path:
+            """Return the temporary runtime workbook path for this test.
+
+            Inputs:
+                None.
+
+            Outputs:
+                The path to the workbook created by
+                :func:`_build_runtime_workbook`.
+
+            External dependencies:
+                None.
+            """
+
+            return workbook_path
+
+        expense_workflow._workbook_path = _runtime_workbook_path
+
+        try:
+            client = app.test_client()
+            with client.session_transaction() as session:
+                session["_user_id"] = str(employee.id)
+                session["_fresh"] = True
+
+            new_expense_response = client.get("/expenses/new")
+            gl_accounts_response = client.get("/expenses/gl-accounts")
+
+            assert new_expense_response.status_code == 200
+            assert gl_accounts_response.status_code == 200
+            assert gl_accounts_response.json == {
+                "accounts": [{"account": "6100", "label": "6100 - Travel Expense"}]
+            }
+        finally:
+            expense_workflow._workbook_path = original_workbook_path_loader
+            expense_workflow.load_gl_accounts.cache_clear()
+            expense_workflow.load_expense_types.cache_clear()


### PR DESCRIPTION
### Motivation
- Ensure the runtime workbook `expense_report_template.xlsx` is included in the Docker build context so spreadsheet-backed features are available at runtime.
- Prefer a narrow exception instead of unignoring all spreadsheets so large/local workbooks remain excluded by default.
- Verify endpoints that read the workbook (`/expenses/new` and `/expenses/gl-accounts`) behave correctly when the template is present at the expected runtime location.

### Description
- Update `.dockerignore` to keep the general `*.xlsx` ignore while explicitly allowing `!expense_report_template.xlsx`.
- Add `tests/test_docker_workbook_packaging.py` to assert `.dockerignore` contains `*.xlsx` and the exception `!expense_report_template.xlsx`, and that the `Dockerfile` uses `WORKDIR /app` and `COPY . .` so the template lands at `/app/expense_report_template.xlsx` in the image.
- Add `tests/test_expense_workbook_runtime_endpoints.py` which creates a minimal XLSX template at a temporary runtime path, overrides `app.services.expense_workflow._workbook_path` for the test, clears relevant caches, seeds an approved employee and supervisor in an in-memory DB, removes the startup maintenance-mode guard so endpoints are reachable after table creation, and asserts `GET /expenses/new` returns `200` and `GET /expenses/gl-accounts` returns `200` with the expected JSON payload.
- Apply `black` formatting to the new test files.

### Testing
- Ran `black` on the new test files, which completed successfully.
- Ran the full test suite with `pytest`, and all tests passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69852a18236883339d5aec08cfc6b7a5)