### PR TITLE
Handle missing expense workbook with controlled 503 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ and administrators manage access and policy settings.
 - `/help/password-reset` - password reset walkthrough
 - `/help/register` - account setup guide
 
+## Runtime dependency: expense workbook template
+
+The expense submission routes depend on a runtime workbook file named
+`expense_report_template.xlsx`.
+
+- Expected location: repository/runtime root next to the `app/` package
+  (for this codebase, that resolves to `<deploy_root>/expense_report_template.xlsx`).
+- Required sheets: `GL Accounts` and `Data List`.
+
+If this file is missing, inaccessible, or malformed, `/expenses/new` and
+`/expenses/gl-accounts` will return controlled `503 Service Unavailable`
+responses so operators can correct deployment configuration.
+
 ## Onboarding checklist
 
 1. Register a new account from `/register`.


### PR DESCRIPTION
### Motivation

- Prevent unhandled exceptions when the runtime `expense_report_template.xlsx` is missing, malformed, or missing required sheets so the app doesn't crash for operators or users.
- Surface a clear, operator-facing error message indicating the expected path and required sheets (`GL Accounts`, `Data List`) to aid remediation.
- Ensure both HTML and JSON endpoints return controlled, user/operator-friendly responses instead of raw tracebacks.

### Description

- Added a domain exception `ExpenseReferenceDataError` and a centralized loader helper ` _load_reference_workbook(required_sheet=...)` in `app/services/expense_workflow.py` that catches `FileNotFoundError`, sheet `KeyError`, `openpyxl` read errors, and raises a clear, actionable message; callers receive an open workbook and must close it.
- Updated `load_gl_accounts` and `load_expense_types` to use ` _load_reference_workbook` so workbook validation is centralized and consistent.
- Updated route handlers in `app/expenses.py` to catch `ExpenseReferenceDataError`: `gl_accounts_options` now returns a JSON error payload with HTTP `503`, and `new_expense` flashes a friendly message and renders the `500.html` fallback with HTTP `503`.
- Added/refactored integration tests in `tests/test_expense_workbook_runtime_endpoints.py` to exercise both the normal runtime-workbook path and the missing-workbook scenario, and documented the runtime dependency in `README.md` (expected file location and required sheets).

### Testing

- Ran the full test suite with `pytest` and all tests passed: `28 passed`.
- Exercised updated integration tests in `tests/test_expense_workbook_runtime_endpoints.py` which validate both success with a runtime workbook and controlled `503` responses when the workbook is missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69852b5b1a548333b62dec3ff1f7c96d)