### PR TITLE
Add supervisor role and tighten expense review access

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -48,11 +48,12 @@ class User(UserMixin, db.Model):
         company_phone: Contact phone number for the user's company.
         role: Application role flag used to enable privileged employee or
             administrative features. Acceptable values are ``"customer"``,
-            ``"employee"``, or ``"super_admin"`` and the field defaults to
-            ``"customer"``.
-        employee_approved: Boolean gating elevated employee-only features.
-            Set to ``True`` when the account has been vetted for internal tool
-            access.
+            ``"employee"``, ``"supervisor"``, or ``"super_admin"`` and the
+            field defaults to ``"customer"``. Supervisors are the approved
+            reviewers for expense reports.
+        employee_approved: Boolean gating elevated employee-only features,
+            including supervisor review access. Set to ``True`` when the
+            account has been vetted for internal tool access.
         admin_previous_role: Cached role restored when administrative access is
             revoked. Persisted only while :attr:`is_admin` is ``True``.
         admin_previous_employee_approved: Cached ``employee_approved`` value
@@ -74,13 +75,13 @@ class User(UserMixin, db.Model):
     password_hash = db.Column(db.String(255), nullable=False)
     is_admin = db.Column(db.Boolean, default=False)
     role: Mapped[str] = db.Column(
-        Enum("customer", "employee", "super_admin", name="user_role"),
+        Enum("customer", "employee", "supervisor", "super_admin", name="user_role"),
         nullable=False,
         default="customer",
     )
     employee_approved: Mapped[bool] = db.Column(Boolean, nullable=False, default=False)
     admin_previous_role: Mapped[Optional[str]] = db.Column(
-        Enum("customer", "employee", name="user_admin_previous_role"),
+        Enum("customer", "employee", "supervisor", name="user_admin_previous_role"),
         nullable=True,
     )
     admin_previous_employee_approved: Mapped[Optional[bool]] = db.Column(

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,16 +44,18 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a>
             </li>
-            {% elif current_user.role == 'employee' and current_user.employee_approved %}
+            {% elif current_user.role in ['employee', 'supervisor'] and current_user.employee_approved %}
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('admin.dashboard') }}">Team Dashboard</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('expenses.new_expense') }}">New Expense</a>
             </li>
+            {% if current_user.role == 'supervisor' %}
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('expenses.supervisor_dashboard') }}">Pending Review</a>
             </li>
+            {% endif %}
             {% endif %}
             <li class="nav-item dropdown">
               <a

--- a/templates/expenses/new_expense.html
+++ b/templates/expenses/new_expense.html
@@ -14,13 +14,14 @@
       <input type="month" name="report_month" class="form-control" required />
     </div>
     <div class="col-md-4">
-      <label class="form-label">Supervisor</label>
+      <label class="form-label">Supervisor (approved reviewers only)</label>
       <select class="form-select" name="supervisor_id" required>
         <option value="">Select supervisor</option>
         {% for supervisor in supervisors %}
         <option value="{{ supervisor.id }}">{{ supervisor.first_name or '' }} {{ supervisor.last_name or supervisor.email }}</option>
         {% endfor %}
       </select>
+      <div class="form-text">Only approved supervisors appear in this list.</div>
     </div>
     <div class="col-md-4">
       <label class="form-label">Notes</label>

--- a/templates/help/expense_workflow.html
+++ b/templates/help/expense_workflow.html
@@ -26,7 +26,7 @@
       <div class="card-body">
         <h2 class="h4">2) Supervisor review</h2>
         <ul class="mb-0">
-          <li>Supervisors review pending reports from the dashboard assigned to their team.</li>
+          <li>Approved supervisors review pending reports from the dashboard assigned to their team.</li>
           <li>They validate policy compliance, spending reasonableness, and documentation quality.</li>
           <li>Missing details usually result in rejection comments so the employee can update and resubmit.</li>
         </ul>

--- a/tests/test_supervisor_access_controls.py
+++ b/tests/test_supervisor_access_controls.py
@@ -1,0 +1,62 @@
+"""Tests for supervisor access controls and picker eligibility."""
+
+from pathlib import Path
+
+
+def test_supervisor_routes_require_supervisor_role() -> None:
+    """Ensure supervisor-only routes use the supervisor role guard.
+
+    Inputs:
+        None. Reads ``app/expenses.py`` to verify decorator usage.
+
+    Outputs:
+        None. Asserts the supervisor-only decorator is applied to routes.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    source = Path("app/expenses.py").read_text(encoding="utf-8")
+
+    assert "@supervisor_required(approved_only=True)" in source
+    assert '@expenses_bp.route("/supervisor")' in source
+    assert '@expenses_bp.route("/supervisor/report/<int:report_id>", methods=["GET", "POST"])' in source
+
+
+def test_supervisor_required_enforces_approval() -> None:
+    """Ensure supervisor access checks require approval for supervisors.
+
+    Inputs:
+        None. Reads ``app/policies.py`` to verify approval checks.
+
+    Outputs:
+        None. Asserts supervisors are subject to ``employee_approved`` checks.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    source = Path("app/policies.py").read_text(encoding="utf-8")
+
+    assert "def supervisor_required" in source
+    assert 'roles_required("supervisor", require_employee_approval=approved_only)' in source
+    assert 'user_role in {"employee", "supervisor"}' in source
+
+
+def test_supervisor_picker_filters_approved_supervisors() -> None:
+    """Ensure the supervisor picker is limited to approved supervisors.
+
+    Inputs:
+        None. Reads ``app/expenses.py`` to verify the query filters.
+
+    Outputs:
+        None. Asserts the supervisor query includes role and approval checks.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    source = Path("app/expenses.py").read_text(encoding="utf-8")
+
+    assert 'User.role == "supervisor"' in source
+    assert "User.employee_approved.is_(True)" in source


### PR DESCRIPTION
### Motivation
- Introduce a clear supervisor role so expense review responsibilities can be enforced separately from generic employees and admin accounts.
- Ensure only vetted, approved supervisors can review reports and be selected in the supervisor picker to reduce accidental or unauthorized approvals.

### Description
- Add `"supervisor"` to the `User.role` enum and document the supervisor behavior in the model docstring (file: `app/models.py`).
- Update role expansion and approval checks in `roles_required` so `employee` includes `supervisor` and `require_employee_approval` applies to both employees and supervisors, and add a new `supervisor_required` decorator (file: `app/policies.py`).
- Restrict the supervisor picker in `new_expense` to only users with `User.role == "supervisor"` and `User.employee_approved.is_(True)`, and validate selected supervisors with the same constraints (file: `app/expenses.py`).
- Apply `@supervisor_required(approved_only=True)` to `expenses.supervisor_dashboard` and `expenses.review_report` so only approved supervisors can access those routes (file: `app/expenses.py`).
- Update navigation and templates to show the "Pending Review" link only to supervisors and clarify supervisor eligibility in the expense form and help text (`templates/base.html`, `templates/expenses/new_expense.html`, `templates/help/expense_workflow.html`).
- Add tests verifying decorator usage, approval enforcement, and the supervisor picker query (`tests/test_supervisor_access_controls.py`).

### Testing
- Ran the full test suite with `pytest`; all tests passed: `31 passed, 8 warnings`.
- New tests added: `tests/test_supervisor_access_controls.py`, and the suite was executed successfully as part of verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69865932670083338a3479881fd61e9c)