### PR TITLE
Add admin review area for pending expense reports

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -43,11 +43,13 @@ from .scripts.import_air_rates import save_unique
 from .models import (
     AppSetting,
     CostZone,
+    ExpenseReport,
     User,
     db,
 )
 from . import csrf
 from .policies import employee_required, super_admin_required
+from app.services.expense_workflow import apply_report_review_action
 from app.services.rate_sets import (
     DEFAULT_RATE_SET,
     get_available_rate_sets,
@@ -56,6 +58,28 @@ from app.services.rate_sets import (
 from app.services.settings import get_settings_cache, reload_overrides, set_setting
 
 admin_bp = Blueprint("admin", __name__, template_folder="templates")
+
+
+def _pending_review_reports() -> List[ExpenseReport]:
+    """Return expense reports that are awaiting supervisor review.
+
+    Inputs:
+        None.
+
+    Outputs:
+        A list of :class:`app.models.ExpenseReport` records ordered by oldest
+        submission first so the admin dashboard can surface priority reviews.
+
+    External dependencies:
+        * Queries :class:`app.models.ExpenseReport` via SQLAlchemy to filter on
+          ``status="Pending Review"``.
+    """
+
+    return (
+        ExpenseReport.query.filter_by(status="Pending Review")
+        .order_by(ExpenseReport.created_at.asc())
+        .all()
+    )
 
 
 def _sync_admin_role(
@@ -401,12 +425,17 @@ def dashboard() -> str:
     :class:`app.models.User` records while approved employees are directed to a
     lightweight panel that links to :func:`quote.admin_view.quotes_html`.
 
+    Inputs:
+        None.
+
     Returns:
         str: Rendered HTML for either ``admin_dashboard.html`` or
         ``admin_employee_dashboard.html`` depending on the caller's role.
 
     External dependencies:
         * :class:`app.models.User` to populate the administrator table.
+        * :class:`app.models.ExpenseReport` to surface pending reviews for
+          super administrators.
         * :data:`flask_login.current_user` to branch between templates.
     """
 
@@ -414,13 +443,62 @@ def dashboard() -> str:
         current_user, "is_admin", False
     ):
         users = User.query.order_by(User.created_at.desc()).all()
+        pending_reports = _pending_review_reports()
         return render_template(
             "admin_dashboard.html",
             users=users,
+            pending_reports=pending_reports,
             settings_url=url_for("admin.list_settings"),
         )
 
     return render_template("admin_employee_dashboard.html")
+
+
+@admin_bp.route("/reports/<int:report_id>/review", methods=["GET", "POST"])
+@super_admin_required
+def review_report(report_id: int) -> Union[str, Response]:
+    """Review a pending expense report from the admin dashboard.
+
+    Inputs:
+        report_id: Unique identifier of the :class:`app.models.ExpenseReport`
+            targeted for review.
+
+    Outputs:
+        A rendered HTML page for GET requests or a redirect response after
+        applying the review decision on POST.
+
+    External dependencies:
+        * Calls :func:`app.services.expense_workflow.apply_report_review_action`
+          to update the report status and rejection comments.
+        * Uses :class:`app.models.ExpenseReport` to load persisted report data.
+        * Writes updates through :data:`app.models.db.session`.
+    """
+
+    report = ExpenseReport.query.get_or_404(report_id)
+    if report.status != "Pending Review":
+        flash("That report is not awaiting review.", "info")
+        return redirect(url_for("admin.dashboard"))
+
+    if request.method == "POST":
+        action = (request.form.get("action") or "").strip()
+        comment = (request.form.get("comment") or "").strip()
+
+        try:
+            message, category = apply_report_review_action(
+                report,
+                action=action,
+                comment=comment,
+            )
+        except ValueError as exc:
+            flash(str(exc), "warning")
+            return redirect(url_for("admin.review_report", report_id=report_id))
+
+        db.session.add(report)
+        db.session.commit()
+        flash(message, category)
+        return redirect(url_for("admin.dashboard"))
+
+    return render_template("expenses/review_report.html", report=report)
 
 
 @admin_bp.route("/settings")

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -16,6 +16,40 @@
       </div>
     </div>
   </section>
+  <section class="dashboard-table mt-4" aria-label="Pending report reviews">
+    <h2 class="h4">Pending Report Reviews</h2>
+    <div class="table-responsive">
+      <table class="table table-striped align-middle mb-0">
+        <thead>
+          <tr>
+            <th>Report</th>
+            <th>Employee</th>
+            <th>Report Month</th>
+            <th>Submitted</th>
+            <th>Review</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for report in pending_reports %}
+          <tr>
+            <td>#{{ report.id }}</td>
+            <td>{{ report.employee.first_name or report.employee.email }}</td>
+            <td>{{ report.report_month.strftime('%Y-%m') }}</td>
+            <td>{{ report.created_at.strftime('%Y-%m-%d') }}</td>
+            <td>
+              <a class="btn btn-sm btn-primary" href="{{ url_for('admin.review_report', report_id=report.id) }}">Review</a>
+            </td>
+          </tr>
+          {% endfor %}
+          {% if not pending_reports %}
+          <tr>
+            <td colspan="5" class="text-muted">No reports pending review.</td>
+          </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
   <div class="dashboard-table">
     <div class="table-responsive">
       <table class="table table-striped align-middle mb-0">

--- a/tests/test_admin_pending_reports.py
+++ b/tests/test_admin_pending_reports.py
@@ -1,0 +1,60 @@
+"""Tests covering admin pending review dashboard additions."""
+
+from pathlib import Path
+
+
+def test_admin_dashboard_includes_pending_report_section() -> None:
+    """Ensure the admin dashboard template includes pending report markup.
+
+    Inputs:
+        None. Reads the admin dashboard template from the repository.
+
+    Outputs:
+        None. Asserts the pending report section and review link exist.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read template text from disk.
+    """
+
+    template = Path("templates/admin_dashboard.html").read_text(encoding="utf-8")
+
+    assert "Pending Report Reviews" in template
+    assert "pending_reports" in template
+    assert "admin.review_report" in template
+
+
+def test_admin_review_route_requires_super_admin() -> None:
+    """Ensure the admin review route uses super admin access control.
+
+    Inputs:
+        None. Reads the admin blueprint source file.
+
+    Outputs:
+        None. Asserts the review route is protected by ``super_admin_required``.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    source = Path("app/admin.py").read_text(encoding="utf-8")
+
+    assert '@admin_bp.route("/reports/<int:report_id>/review"' in source
+    assert "@super_admin_required" in source
+
+
+def test_admin_dashboard_loads_pending_reports() -> None:
+    """Ensure the admin dashboard queries pending reports.
+
+    Inputs:
+        None. Reads the admin blueprint source file.
+
+    Outputs:
+        None. Asserts the pending review query helper is invoked.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    source = Path("app/admin.py").read_text(encoding="utf-8")
+
+    assert "pending_reports = _pending_review_reports()" in source


### PR DESCRIPTION
### Motivation
- Administrators need a way to open and review expense reports that are awaiting supervisor action without switching to a supervisor account.
- Consolidate review logic so supervisors and admins behave consistently when approving/rejecting reports.

### Description
- Added a shared helper `apply_report_review_action` in `app/services/expense_workflow.py` to centralize approve/reject logic and validation.
- Surface pending reviews on the admin landing page by adding `_pending_review_reports()` and passing `pending_reports` into the `admin_dashboard` view in `app/admin.py`.
- Added an admin review route `@admin_bp.route("/reports/<int:report_id>/review")` protected by `@super_admin_required` that reuses `apply_report_review_action` and renders the existing `expenses/review_report.html` template.
- Updated `templates/admin_dashboard.html` to render a `Pending Report Reviews` table with links to the new admin review route.
- Updated supervisor review flow in `app/expenses.py` to reuse `apply_report_review_action` for consistent behavior and messaging.
- Added unit tests in `tests/test_admin_pending_reports.py` to assert template/route changes and the dashboard loads pending reports.

### Testing
- Ran the full test suite with `pytest`, which passed: `34 passed` (no failures).
- Added and executed `tests/test_admin_pending_reports.py`, which validated the new template section, route protection, and that the dashboard queries pending reports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69866028309883339c289f7e28cdca37)