### PR TITLE
Add per-line review decisions for expense reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and administrators manage access and policy settings.
 
 - Employee authentication (register, sign in, reset password)
 - Expense report creation and submission
-- Supervisor review and approval workflow
+- Supervisor line-by-line review and approval workflow
 - Admin dashboards for user and settings management
 - Audit-friendly persistence of submitted reports and status changes
 

--- a/app/models.py
+++ b/app/models.py
@@ -287,7 +287,8 @@ class ExpenseLine(db.Model):
     """Individual expense row attached to an :class:`ExpenseReport`.
 
     The columns mirror the spreadsheet-driven workflow used by employees for
-    monthly reimbursement submissions.
+    monthly reimbursement submissions. Each line can be reviewed independently
+    to capture approval or rejection feedback on a per-expense basis.
     """
 
     __tablename__ = EXPENSE_LINES_TABLE
@@ -306,4 +307,15 @@ class ExpenseLine(db.Model):
     amount = db.Column(db.Numeric(10, 2), nullable=False)
     description = db.Column(db.String(255))
     receipt_url = db.Column(db.String(1024))
+    status: Mapped[str] = db.Column(
+        Enum(
+            "Pending Review",
+            "Approved",
+            "Rejected",
+            name="expense_line_status",
+        ),
+        nullable=False,
+        default="Pending Review",
+    )
+    rejection_comment = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/migrations/versions/20260215_01_add_expense_line_review_fields.py
+++ b/migrations/versions/20260215_01_add_expense_line_review_fields.py
@@ -1,0 +1,55 @@
+"""Add line-level review status and comments to expense lines.
+
+Revision ID: 20260215_01
+Revises: 20260205_01
+Create Date: 2026-02-15
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260215_01"
+down_revision = "20260205_01"
+branch_labels = None
+depends_on = None
+
+
+LINE_STATUS_ENUM = sa.Enum(
+    "Pending Review",
+    "Approved",
+    "Rejected",
+    name="expense_line_status",
+)
+
+
+def upgrade() -> None:
+    """Add status and rejection comment columns for expense lines."""
+
+    connection = op.get_bind()
+    LINE_STATUS_ENUM.create(connection, checkfirst=True)
+
+    op.add_column(
+        "expense_lines",
+        sa.Column(
+            "status",
+            LINE_STATUS_ENUM,
+            nullable=False,
+            server_default="Pending Review",
+        ),
+    )
+    op.add_column(
+        "expense_lines",
+        sa.Column("rejection_comment", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove line-level status and comment fields from expense lines."""
+
+    op.drop_column("expense_lines", "rejection_comment")
+    op.drop_column("expense_lines", "status")
+    connection = op.get_bind()
+    LINE_STATUS_ENUM.drop(connection, checkfirst=True)

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -16,6 +16,40 @@
       </div>
     </div>
   </section>
+  <section class="dashboard-table mt-4" aria-label="Pending report reviews">
+    <h2 class="h4">Pending Report Reviews</h2>
+    <div class="table-responsive">
+      <table class="table table-striped align-middle mb-0">
+        <thead>
+          <tr>
+            <th>Report</th>
+            <th>Employee</th>
+            <th>Report Month</th>
+            <th>Submitted</th>
+            <th>Review</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for report in pending_reports %}
+          <tr>
+            <td>#{{ report.id }}</td>
+            <td>{{ report.employee.first_name or report.employee.email }}</td>
+            <td>{{ report.report_month.strftime('%Y-%m') }}</td>
+            <td>{{ report.created_at.strftime('%Y-%m-%d') }}</td>
+            <td>
+              <a class="btn btn-sm btn-primary" href="{{ url_for('admin.review_report', report_id=report.id) }}">Review</a>
+            </td>
+          </tr>
+          {% endfor %}
+          {% if not pending_reports %}
+          <tr>
+            <td colspan="5" class="text-muted">No reports pending review.</td>
+          </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
   <div class="dashboard-table">
     <div class="table-responsive">
       <table class="table table-striped align-middle mb-0">

--- a/templates/expenses/review_report.html
+++ b/templates/expenses/review_report.html
@@ -5,34 +5,78 @@
 <p><strong>Employee:</strong> {{ report.employee.first_name or report.employee.email }}</p>
 <p><strong>Status:</strong> {{ report.status }}</p>
 
-<div class="table-responsive mb-3">
-  <table class="table table-bordered">
-    <thead><tr><th>Date</th><th>Type</th><th>GL</th><th>Vendor</th><th>Description</th><th>Amount</th><th>Receipt</th></tr></thead>
-    <tbody>
-      {% for line in report.lines %}
-      <tr>
-        <td>{{ line.date.strftime('%Y-%m-%d') }}</td>
-        <td>{{ line.expense_type }}</td>
-        <td>{{ line.gl_account }}</td>
-        <td>{{ line.vendor }}</td>
-        <td>{{ line.description }}</td>
-        <td>${{ '%.2f'|format(line.amount) }}</td>
-        <td>{% if line.receipt_url %}<a href="{{ line.receipt_url }}" target="_blank" rel="noopener">View</a>{% else %}<span class="text-muted">None</span>{% endif %}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
-
 <form method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-  <div class="mb-3">
-    <label class="form-label">Rejection Comment (required for reject)</label>
-    <textarea class="form-control" name="comment" rows="3"></textarea>
+  <div class="table-responsive mb-3">
+    <table class="table table-bordered align-middle">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Type</th>
+          <th>GL</th>
+          <th>Vendor</th>
+          <th>Description</th>
+          <th>Amount</th>
+          <th>Receipt</th>
+          <th>Decision</th>
+          <th>Line Comment</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for line in report.lines %}
+        <tr>
+          <td>{{ line.date.strftime('%Y-%m-%d') }}</td>
+          <td>{{ line.expense_type }}</td>
+          <td>{{ line.gl_account }}</td>
+          <td>{{ line.vendor }}</td>
+          <td>{{ line.description }}</td>
+          <td>${{ '%.2f'|format(line.amount) }}</td>
+          <td>
+            {% if line.receipt_url %}
+            <a href="{{ line.receipt_url }}" target="_blank" rel="noopener">View</a>
+            {% else %}
+            <span class="text-muted">None</span>
+            {% endif %}
+          </td>
+          <td>
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="radio"
+                name="line_status_{{ line.id }}"
+                id="line-{{ line.id }}-approve"
+                value="approve"
+                required
+              />
+              <label class="form-check-label" for="line-{{ line.id }}-approve">Approve</label>
+            </div>
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="radio"
+                name="line_status_{{ line.id }}"
+                id="line-{{ line.id }}-reject"
+                value="reject"
+              />
+              <label class="form-check-label" for="line-{{ line.id }}-reject">Reject</label>
+            </div>
+          </td>
+          <td>
+            <textarea
+              class="form-control"
+              name="line_comment_{{ line.id }}"
+              rows="2"
+              placeholder="Required when rejecting."
+            ></textarea>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
+  <p class="text-muted small mb-3">Rejected lines require a comment.</p>
   <div class="d-flex gap-2">
-    <button class="btn btn-success" name="action" value="approve">Approve</button>
-    <button class="btn btn-danger" name="action" value="reject">Reject</button>
+    <button class="btn btn-primary" type="submit">Finalize Report</button>
   </div>
 </form>
 {% endblock %}

--- a/templates/help/expense_workflow.html
+++ b/templates/help/expense_workflow.html
@@ -27,8 +27,8 @@
         <h2 class="h4">2) Supervisor review</h2>
         <ul class="mb-0">
           <li>Approved supervisors review pending reports from the dashboard assigned to their team.</li>
-          <li>They validate policy compliance, spending reasonableness, and documentation quality.</li>
-          <li>Missing details usually result in rejection comments so the employee can update and resubmit.</li>
+          <li>They validate policy compliance, spending reasonableness, and documentation quality line by line.</li>
+          <li>Rejected lines require comments so the employee can update and resubmit the report.</li>
         </ul>
       </div>
     </div>
@@ -39,7 +39,8 @@
         <ul class="mb-0">
           <li><strong>Draft</strong>: report is still editable by the employee.</li>
           <li><strong>Submitted</strong>: report is queued for supervisor action.</li>
-          <li><strong>Approved</strong> or <strong>Rejected</strong>: final decision with optional reviewer comments.</li>
+          <li><strong>Pending Upload</strong>: report moves to finance when every line is approved.</li>
+          <li><strong>Draft (Returned)</strong>: report returns for updates when any line is rejected.</li>
         </ul>
       </div>
     </div>

--- a/tests/test_admin_pending_reports.py
+++ b/tests/test_admin_pending_reports.py
@@ -1,0 +1,60 @@
+"""Tests covering admin pending review dashboard additions."""
+
+from pathlib import Path
+
+
+def test_admin_dashboard_includes_pending_report_section() -> None:
+    """Ensure the admin dashboard template includes pending report markup.
+
+    Inputs:
+        None. Reads the admin dashboard template from the repository.
+
+    Outputs:
+        None. Asserts the pending report section and review link exist.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read template text from disk.
+    """
+
+    template = Path("templates/admin_dashboard.html").read_text(encoding="utf-8")
+
+    assert "Pending Report Reviews" in template
+    assert "pending_reports" in template
+    assert "admin.review_report" in template
+
+
+def test_admin_review_route_requires_super_admin() -> None:
+    """Ensure the admin review route uses super admin access control.
+
+    Inputs:
+        None. Reads the admin blueprint source file.
+
+    Outputs:
+        None. Asserts the review route is protected by ``super_admin_required``.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    source = Path("app/admin.py").read_text(encoding="utf-8")
+
+    assert '@admin_bp.route("/reports/<int:report_id>/review"' in source
+    assert "@super_admin_required" in source
+
+
+def test_admin_dashboard_loads_pending_reports() -> None:
+    """Ensure the admin dashboard queries pending reports.
+
+    Inputs:
+        None. Reads the admin blueprint source file.
+
+    Outputs:
+        None. Asserts the pending review query helper is invoked.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read source text from the repository.
+    """
+
+    source = Path("app/admin.py").read_text(encoding="utf-8")
+
+    assert "pending_reports = _pending_review_reports()" in source

--- a/tests/test_expense_line_review.py
+++ b/tests/test_expense_line_review.py
@@ -1,0 +1,95 @@
+"""Tests for line-by-line expense report review decisions."""
+
+from types import SimpleNamespace
+from pathlib import Path
+
+from app.services.expense_workflow import (
+    ExpenseLineDecision,
+    apply_line_review_decisions,
+)
+
+
+def test_apply_line_review_decisions_approves_all_lines() -> None:
+    """Approve a report when every line is marked approved.
+
+    Inputs:
+        None. Builds in-memory line objects to exercise the helper.
+
+    Outputs:
+        None. Asserts report and line statuses update correctly.
+
+    External dependencies:
+        Calls :func:`app.services.expense_workflow.apply_line_review_decisions`.
+    """
+
+    line_one = SimpleNamespace(id=1, status="Pending Review", rejection_comment=None)
+    line_two = SimpleNamespace(id=2, status="Pending Review", rejection_comment=None)
+    report = SimpleNamespace(
+        lines=[line_one, line_two],
+        status="Pending Review",
+        rejection_comment="",
+    )
+
+    decisions = (
+        ExpenseLineDecision(line_id=1, status="approve", comment=""),
+        ExpenseLineDecision(line_id=2, status="approve", comment=""),
+    )
+
+    message, category = apply_line_review_decisions(report, decisions=decisions)
+
+    assert report.status == "Pending Upload"
+    assert report.rejection_comment is None
+    assert line_one.status == "Approved"
+    assert line_two.status == "Approved"
+    assert message
+    assert category == "success"
+
+
+def test_apply_line_review_decisions_requires_rejection_comment() -> None:
+    """Rejecting a line requires a comment for traceability.
+
+    Inputs:
+        None. Builds in-memory line objects to exercise the helper.
+
+    Outputs:
+        None. Asserts the helper raises for missing rejection comments.
+
+    External dependencies:
+        Calls :func:`app.services.expense_workflow.apply_line_review_decisions`.
+    """
+
+    line_one = SimpleNamespace(id=10, status="Pending Review", rejection_comment=None)
+    report = SimpleNamespace(
+        lines=[line_one],
+        status="Pending Review",
+        rejection_comment="",
+    )
+
+    decisions = (ExpenseLineDecision(line_id=10, status="reject", comment=""),)
+
+    try:
+        apply_line_review_decisions(report, decisions=decisions)
+    except ValueError as exc:
+        assert "comment" in str(exc).lower()
+    else:
+        raise AssertionError("Expected ValueError for missing rejection comment")
+
+
+def test_review_report_template_includes_line_decisions() -> None:
+    """Ensure the review template exposes line decision controls.
+
+    Inputs:
+        None. Reads the report review template from disk.
+
+    Outputs:
+        None. Asserts the template includes line decision fields.
+
+    External dependencies:
+        Uses :class:`pathlib.Path` to read repository files.
+    """
+
+    template = Path("templates/expenses/review_report.html").read_text(encoding="utf-8")
+
+    assert "line_status_" in template
+    assert "line_comment_" in template
+    assert "Finalize Report" in template


### PR DESCRIPTION
### Motivation
- Supervisors and admins must be able to approve or reject each expense line individually and then finalize the report so final status reflects line-level decisions.

### Description
- Add per-line persistence by adding `status` and `rejection_comment` fields to `ExpenseLine` and include a new migration `migrations/versions/20260215_01_add_expense_line_review_fields.py` to apply the schema change.
- Introduce `ExpenseLineDecision` and two helpers in `app/services/expense_workflow.py`: `parse_line_review_form_data` to collect form payloads and `apply_line_review_decisions` to validate/apply decisions and set the report status (`Pending Upload` when all lines approved, `Draft` when any line rejected).
- Update supervisor and admin review endpoints to use the new parsing/application helpers (`app/expenses.py` and `app/admin.py`) and add `_pending_review_reports()` to surface pending reviews on the admin dashboard.
- Replace the single approve/reject UI with a line-by-line review UI in `templates/expenses/review_report.html`, update help copy in `templates/help/expense_workflow.html`, and update the `README.md` to reflect the line-by-line workflow.
- Add tests covering line-level review logic and template/route additions (`tests/test_expense_line_review.py` and `tests/test_admin_pending_reports.py`).

### Testing
- Ran the full test suite with `pytest`; all tests passed: `37 passed`.
- The new tests `tests/test_expense_line_review.py` and `tests/test_admin_pending_reports.py` were executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69866028309883339c289f7e28cdca37)