### PR TITLE
Add line-level expense review workflow

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -287,7 +287,8 @@ class ExpenseLine(db.Model):
     """Individual expense row attached to an :class:`ExpenseReport`.
 
     The columns mirror the spreadsheet-driven workflow used by employees for
-    monthly reimbursement submissions.
+    monthly reimbursement submissions. Supervisors review each line item during
+    report approval to capture granular approval and rejection feedback.
     """
 
     __tablename__ = EXPENSE_LINES_TABLE
@@ -306,4 +307,15 @@ class ExpenseLine(db.Model):
     amount = db.Column(db.Numeric(10, 2), nullable=False)
     description = db.Column(db.String(255))
     receipt_url = db.Column(db.String(1024))
+    review_status: Mapped[str] = db.Column(
+        Enum(
+            "Pending",
+            "Approved",
+            "Rejected",
+            name="expense_line_review_status",
+        ),
+        nullable=False,
+        default="Pending",
+    )
+    review_comment = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/migrations/versions/20260310_01_add_expense_line_review_fields.py
+++ b/migrations/versions/20260310_01_add_expense_line_review_fields.py
@@ -1,0 +1,54 @@
+"""Add line-level review fields to expense lines.
+
+Revision ID: 20260310_01
+Revises: 20260205_01
+Create Date: 2026-03-10
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260310_01"
+down_revision = "20260205_01"
+branch_labels = None
+depends_on = None
+
+REVIEW_STATUS_ENUM = sa.Enum(
+    "Pending",
+    "Approved",
+    "Rejected",
+    name="expense_line_review_status",
+)
+
+
+def upgrade() -> None:
+    """Add review status and comment columns to expense line items."""
+
+    connection = op.get_bind()
+    REVIEW_STATUS_ENUM.create(connection, checkfirst=True)
+    op.add_column(
+        "expense_lines",
+        sa.Column(
+            "review_status",
+            REVIEW_STATUS_ENUM,
+            nullable=False,
+            server_default="Pending",
+        ),
+    )
+    op.add_column(
+        "expense_lines",
+        sa.Column("review_comment", sa.Text(), nullable=True),
+    )
+    op.alter_column("expense_lines", "review_status", server_default=None)
+
+
+def downgrade() -> None:
+    """Remove review columns from expense line items."""
+
+    connection = op.get_bind()
+    op.drop_column("expense_lines", "review_comment")
+    op.drop_column("expense_lines", "review_status")
+    REVIEW_STATUS_ENUM.drop(connection, checkfirst=True)

--- a/templates/expenses/review_report.html
+++ b/templates/expenses/review_report.html
@@ -5,34 +5,87 @@
 <p><strong>Employee:</strong> {{ report.employee.first_name or report.employee.email }}</p>
 <p><strong>Status:</strong> {{ report.status }}</p>
 
-<div class="table-responsive mb-3">
-  <table class="table table-bordered">
-    <thead><tr><th>Date</th><th>Type</th><th>GL</th><th>Vendor</th><th>Description</th><th>Amount</th><th>Receipt</th></tr></thead>
-    <tbody>
-      {% for line in report.lines %}
-      <tr>
-        <td>{{ line.date.strftime('%Y-%m-%d') }}</td>
-        <td>{{ line.expense_type }}</td>
-        <td>{{ line.gl_account }}</td>
-        <td>{{ line.vendor }}</td>
-        <td>{{ line.description }}</td>
-        <td>${{ '%.2f'|format(line.amount) }}</td>
-        <td>{% if line.receipt_url %}<a href="{{ line.receipt_url }}" target="_blank" rel="noopener">View</a>{% else %}<span class="text-muted">None</span>{% endif %}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
-
 <form method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-  <div class="mb-3">
-    <label class="form-label">Rejection Comment (required for reject)</label>
-    <textarea class="form-control" name="comment" rows="3"></textarea>
+  <div class="table-responsive mb-3">
+    <table class="table table-bordered align-middle">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Type</th>
+          <th>GL</th>
+          <th>Vendor</th>
+          <th>Description</th>
+          <th>Amount</th>
+          <th>Receipt</th>
+          <th>Decision</th>
+          <th>Reviewer Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for line in report.lines %}
+        <tr>
+          <td>{{ line.date.strftime('%Y-%m-%d') }}</td>
+          <td>{{ line.expense_type }}</td>
+          <td>{{ line.gl_account }}</td>
+          <td>{{ line.vendor }}</td>
+          <td>{{ line.description }}</td>
+          <td>${{ '%.2f'|format(line.amount) }}</td>
+          <td>
+            {% if line.receipt_url %}
+            <a href="{{ line.receipt_url }}" target="_blank" rel="noopener">View</a>
+            {% else %}
+            <span class="text-muted">None</span>
+            {% endif %}
+          </td>
+          <td>
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="radio"
+                name="line_{{ line.id }}_action"
+                id="line-{{ line.id }}-approve"
+                value="approve"
+                required
+                {% if line.review_status == "Approved" %}checked{% endif %}
+              />
+              <label class="form-check-label" for="line-{{ line.id }}-approve">
+                Approve
+              </label>
+            </div>
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="radio"
+                name="line_{{ line.id }}_action"
+                id="line-{{ line.id }}-reject"
+                value="reject"
+                {% if line.review_status == "Rejected" %}checked{% endif %}
+              />
+              <label class="form-check-label" for="line-{{ line.id }}-reject">
+                Reject
+              </label>
+            </div>
+            {% if line.review_status and line.review_status != "Pending" %}
+            <span class="badge bg-secondary mt-2">{{ line.review_status }}</span>
+            {% endif %}
+          </td>
+          <td>
+            <textarea
+              class="form-control"
+              name="line_{{ line.id }}_comment"
+              rows="2"
+              placeholder="Required for rejects"
+            >{{ line.review_comment or "" }}</textarea>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
-  <div class="d-flex gap-2">
-    <button class="btn btn-success" name="action" value="approve">Approve</button>
-    <button class="btn btn-danger" name="action" value="reject">Reject</button>
+  <div class="alert alert-info">
+    Review each line item and add a comment for any rejected expense.
   </div>
+  <button class="btn btn-primary" type="submit">Submit Line Review</button>
 </form>
 {% endblock %}

--- a/templates/help/expense_workflow.html
+++ b/templates/help/expense_workflow.html
@@ -28,7 +28,7 @@
         <ul class="mb-0">
           <li>Approved supervisors review pending reports from the dashboard assigned to their team.</li>
           <li>They validate policy compliance, spending reasonableness, and documentation quality.</li>
-          <li>Missing details usually result in rejection comments so the employee can update and resubmit.</li>
+          <li>Each expense line is approved or rejected with feedback when details are missing.</li>
         </ul>
       </div>
     </div>
@@ -38,8 +38,9 @@
         <h2 class="h4">3) Approvals and status changes</h2>
         <ul class="mb-0">
           <li><strong>Draft</strong>: report is still editable by the employee.</li>
-          <li><strong>Submitted</strong>: report is queued for supervisor action.</li>
-          <li><strong>Approved</strong> or <strong>Rejected</strong>: final decision with optional reviewer comments.</li>
+          <li><strong>Pending Review</strong>: report is queued for supervisor action.</li>
+          <li><strong>Pending Upload</strong>: all lines were approved and the report is queued for finance.</li>
+          <li><strong>Draft</strong> resumes if any line is rejected with reviewer feedback.</li>
         </ul>
       </div>
     </div>

--- a/tests/test_expense_line_review.py
+++ b/tests/test_expense_line_review.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import pytest
+
+from app.services.expense_workflow import apply_line_item_review_actions
+
+
+@dataclass
+class DummyLine:
+    """Minimal expense line for unit testing review decisions.
+
+    Inputs:
+        id: Unique identifier for the line item under review.
+        review_status: Current review state for the line item.
+        review_comment: Optional reviewer notes tied to the line.
+
+    Outputs:
+        A lightweight container for line review attributes used in tests.
+
+    External dependencies:
+        None.
+    """
+
+    id: int
+    review_status: str = "Pending"
+    review_comment: Optional[str] = None
+
+
+@dataclass
+class DummyReport:
+    """Minimal expense report wrapper for unit testing review decisions.
+
+    Inputs:
+        lines: Collection of :class:`DummyLine` entries attached to the report.
+        status: Current report status value.
+        rejection_comment: Optional report-level rejection summary.
+
+    Outputs:
+        A lightweight container for report review attributes used in tests.
+
+    External dependencies:
+        None.
+    """
+
+    lines: List[DummyLine] = field(default_factory=list)
+    status: str = "Pending Review"
+    rejection_comment: Optional[str] = None
+
+
+def test_apply_line_item_review_actions_approves_all_lines() -> None:
+    """Ensure all approved lines move the report to pending upload.
+
+    Inputs:
+        None. Constructs a minimal in-memory report with two line items.
+
+    Outputs:
+        None. Asserts report and line state transitions in memory.
+
+    External dependencies:
+        Calls :func:`app.services.expense_workflow.apply_line_item_review_actions`.
+    """
+
+    report = DummyReport(lines=[DummyLine(id=1), DummyLine(id=2)])
+    decisions = {1: ("approve", ""), 2: ("approve", "")}
+
+    message, category = apply_line_item_review_actions(report, decisions=decisions)
+
+    assert message.startswith("All expense lines approved")
+    assert category == "success"
+    assert report.status == "Pending Upload"
+    assert report.rejection_comment is None
+    assert [line.review_status for line in report.lines] == ["Approved", "Approved"]
+
+
+def test_apply_line_item_review_actions_requires_rejection_comment() -> None:
+    """Rejecting a line without notes should raise a helpful error.
+
+    Inputs:
+        None. Constructs a minimal in-memory report with one line item.
+
+    Outputs:
+        None. Asserts a :class:`ValueError` is raised for missing comments.
+
+    External dependencies:
+        Calls :func:`app.services.expense_workflow.apply_line_item_review_actions`.
+    """
+
+    report = DummyReport(lines=[DummyLine(id=1)])
+    decisions = {1: ("reject", "")}
+
+    with pytest.raises(ValueError, match="rejection comment"):
+        apply_line_item_review_actions(report, decisions=decisions)
+
+
+def test_apply_line_item_review_actions_marks_rejected_lines() -> None:
+    """Rejected lines should return the report to draft with feedback.
+
+    Inputs:
+        None. Constructs a minimal in-memory report with two line items.
+
+    Outputs:
+        None. Asserts report and line state transitions in memory.
+
+    External dependencies:
+        Calls :func:`app.services.expense_workflow.apply_line_item_review_actions`.
+    """
+
+    report = DummyReport(lines=[DummyLine(id=1), DummyLine(id=2)])
+    decisions = {1: ("approve", ""), 2: ("reject", "Missing receipt")}
+
+    message, category = apply_line_item_review_actions(report, decisions=decisions)
+
+    assert message.startswith("Report returned to draft")
+    assert category == "info"
+    assert report.status == "Draft"
+    assert report.rejection_comment == "Line-level feedback provided."
+    assert report.lines[0].review_status == "Approved"
+    assert report.lines[1].review_status == "Rejected"
+    assert report.lines[1].review_comment == "Missing receipt"


### PR DESCRIPTION
### Motivation
- Supervisors need the ability to approve or reject individual expense lines so feedback can be specific and reports can be finalized accurately.
- Export and dispatch should only include fully-approved line items to avoid sending rejected or incomplete data to finance.

### Description
- Added line-level review columns to the model: `ExpenseLine.review_status` and `ExpenseLine.review_comment` and created an Alembic migration `migrations/versions/20260310_01_add_expense_line_review_fields.py` to persist them.
- Replaced the single-report decision helper with `apply_line_item_review_actions` in `app/services/expense_workflow.py` to process a mapping of per-line `(action, comment)` and update both line and report state, and updated `format_pending_reports_csv` to only export lines with `review_status == 'Approved'`.
- Updated supervisor and admin review endpoints to collect per-line decisions and call `apply_line_item_review_actions` (`app/expenses.py` and `app/admin.py`) and refreshed the review UI template `templates/expenses/review_report.html` to present radio buttons and per-line comment fields.
- Updated documentation copy in `templates/help/expense_workflow.html` to describe line-by-line review and added unit tests `tests/test_expense_line_review.py` covering approve/reject flows.

### Testing
- Ran the full test suite with `pytest`, which executed all tests and passed: `37 passed`.
- Formatted modified files with `black` before running tests.

Migration note: run your normal Alembic upgrade step (e.g., `alembic upgrade head`) to add the new `expense_lines.review_status` and `expense_lines.review_comment` columns prior to deploying this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6986681a556483338145110e1c5ae751)